### PR TITLE
feat: scrape Overlay Mix and transition Duration from vMix help 29

### DIFF
--- a/app/src/assets/shortcuts.json
+++ b/app/src/assets/shortcuts.json
@@ -1,1 +1,5648 @@
-[{"Name":"Cut","Description":"Cut","Parameters":["Input","Mix"]},{"Name":"Fade","Description":"Fade","Parameters":["Input","Mix"]},{"Name":"Merge","Description":"Merge","Parameters":["Input"]},{"Name":"Name","Description":"Description","Parameters":["Parameters"]},{"Name":"ActivatorRefresh","Description":"Refresh all activator device lights and controls","Parameters":null},{"Name":"CallManagerShowHide","Description":"","Parameters":null},{"Name":"KeyPress","Description":"Value = Key","Parameters":["Value"]},{"Name":"SendKeys","Description":"Send keys to active window      Value = Keys","Parameters":["Value"]},{"Name":"SetDynamicValue1","Description":"Set Dynamic Value to use when specifying Dynamic1 as a shortcut value.      Value = Value","Parameters":["Value"]},{"Name":"SetDynamicValue2","Description":"Set Dynamic Value to use when specifying Dynamic2 as a shortcut value.      Value = Value","Parameters":["Value"]},{"Name":"SetDynamicValue3","Description":"Set Dynamic Value to use when specifying Dynamic3 as a shortcut value.      Value = Value","Parameters":["Value"]},{"Name":"SetDynamicValue4","Description":"Set Dynamic Value to use when specifying Dynamic4 as a shortcut value.      Value = Value","Parameters":["Value"]},{"Name":"Undo","Description":"Undo closing Input.","Parameters":null},{"Name":"Audio","Description":"Toggle Audio Mute On/Off","Parameters":["Input"]},{"Name":"AudioAuto","Description":"","Parameters":["Input"]},{"Name":"AudioAutoOff","Description":"","Parameters":["Input"]},{"Name":"AudioAutoOn","Description":"","Parameters":["Input"]},{"Name":"AudioBus","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value","Input"]},{"Name":"AudioBusOff","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value","Input"]},{"Name":"AudioBusOn","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value","Input"]},{"Name":"AudioChannelMatrixApplyPreset","Description":"Apply preset to channel matrix      Value = Preset Name","Parameters":["Value","Input"]},{"Name":"AudioMixerShowHide","Description":"","Parameters":null},{"Name":"AudioOff","Description":"","Parameters":["Input"]},{"Name":"AudioOn","Description":"","Parameters":["Input"]},{"Name":"AudioPluginOff","Description":"Turn off Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value","Input"]},{"Name":"AudioPluginOn","Description":"Turn on Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value","Input"]},{"Name":"AudioPluginOnOff","Description":"Toggle on/off Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value","Input"]},{"Name":"AudioPluginShow","Description":"Show Audio Plugin Editor, starting from 1      Value = Plugin Number","Parameters":["Value","Input"]},{"Name":"BusAAudio","Description":"","Parameters":null},{"Name":"BusAAudioOff","Description":"","Parameters":null},{"Name":"BusAAudioOn","Description":"","Parameters":null},{"Name":"BusAAudioPluginOff","Description":"Turn off Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"BusAAudioPluginOn","Description":"Turn on Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"BusAAudioPluginOnOff","Description":"Toggle on/off Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"BusAAudioPluginShow","Description":"Show Audio Plugin Editor, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"BusBAudio","Description":"","Parameters":null},{"Name":"BusBAudioOff","Description":"","Parameters":null},{"Name":"BusBAudioOn","Description":"","Parameters":null},{"Name":"BusBAudioPluginOff","Description":"Turn off Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"BusBAudioPluginOn","Description":"Turn on Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"BusBAudioPluginOnOff","Description":"Toggle on/off Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"BusBAudioPluginShow","Description":"Show Audio Plugin Editor, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"BusXAudio","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value"]},{"Name":"BusXAudioOff","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value"]},{"Name":"BusXAudioOn","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value"]},{"Name":"BusXAudioPluginOff","Description":"Turn off Audio Plugin, starting from 1      Value = Bus,PluginNumber","Parameters":["Value"]},{"Name":"BusXAudioPluginOn","Description":"Turn on Audio Plugin, starting from 1      Value = Bus,PluginNumber","Parameters":["Value"]},{"Name":"BusXAudioPluginOnOff","Description":"Toggle on/off Audio Plugin, starting from 1      Value = Bus,PluginNumber","Parameters":["Value"]},{"Name":"BusXAudioPluginShow","Description":"Show Audio Plugin Editor, starting from 1      Value = Bus,PluginNumber","Parameters":["Value"]},{"Name":"BusXSendToMaster","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value"]},{"Name":"BusXSendToMasterOff","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value"]},{"Name":"BusXSendToMasterOn","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value"]},{"Name":"BusXSolo","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value"]},{"Name":"BusXSoloOff","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value"]},{"Name":"BusXSoloOn","Description":"M,A,B,C,D,E,F,G      Value = Bus","Parameters":["Value"]},{"Name":"MasterAudio","Description":"","Parameters":null},{"Name":"MasterAudioOff","Description":"","Parameters":null},{"Name":"MasterAudioOn","Description":"","Parameters":null},{"Name":"MasterAudioPluginOff","Description":"Turn off Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"MasterAudioPluginOn","Description":"Turn on Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"MasterAudioPluginOnOff","Description":"Toggle on/off Audio Plugin, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"MasterAudioPluginShow","Description":"Show Audio Plugin Editor, starting from 1      Value = Plugin Number","Parameters":["Value"]},{"Name":"SetBalance","Description":"Value = Balance -1-1","Parameters":["Value","Input"]},{"Name":"SetBusAVolume","Description":"Value = Volume 0-100","Parameters":["Value"]},{"Name":"SetBusAVolumeFade","Description":"Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds","Parameters":["Value"]},{"Name":"SetBusBVolume","Description":"Value = Volume 0-100","Parameters":["Value"]},{"Name":"SetBusBVolumeFade","Description":"Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds","Parameters":["Value"]},{"Name":"SetBusCVolume","Description":"Value = Volume 0-100","Parameters":["Value"]},{"Name":"SetBusCVolumeFade","Description":"Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds","Parameters":["Value"]},{"Name":"SetBusDVolume","Description":"Value = Volume 0-100","Parameters":["Value"]},{"Name":"SetBusDVolumeFade","Description":"Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds","Parameters":["Value"]},{"Name":"SetBusEVolume","Description":"Value = Volume 0-100","Parameters":["Value"]},{"Name":"SetBusEVolumeFade","Description":"Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds","Parameters":["Value"]},{"Name":"SetBusFVolume","Description":"Value = Volume 0-100","Parameters":["Value"]},{"Name":"SetBusFVolumeFade","Description":"Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds","Parameters":["Value"]},{"Name":"SetBusGVolume","Description":"Value = Volume 0-100","Parameters":["Value"]},{"Name":"SetBusGVolumeFade","Description":"Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds","Parameters":["Value"]},{"Name":"SetGain","Description":"Value = Gain dB 0-24","Parameters":["Value","Input"]},{"Name":"SetGainChannel1","Description":"Value = Gain dB 0-24","Parameters":["Value","Input"]},{"Name":"SetGainChannel2","Description":"Value = Gain dB 0-24","Parameters":["Value","Input"]},{"Name":"SetHeadphonesVolume","Description":"Value = Volume 0-100","Parameters":["Value"]},{"Name":"SetMasterVolume","Description":"Value = Volume 0-100","Parameters":["Value"]},{"Name":"SetMasterVolumeFade","Description":"Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds","Parameters":["Value"]},{"Name":"SetVolume","Description":"Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeBusMixer","Description":"Set Volume of an Input's Bus Mixer (M,A,B,C,D,E,F,G)      Value = Bus,Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeBusMixerA","Description":"Set Volume of an Input's A Bus      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeBusMixerB","Description":"Set Volume of an Input's B Bus      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeBusMixerC","Description":"Set Volume of an Input's C Bus      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeBusMixerD","Description":"Set Volume of an Input's D Bus      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeBusMixerE","Description":"Set Volume of an Input's E Bus      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeBusMixerF","Description":"Set Volume of an Input's F Bus      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeBusMixerG","Description":"Set Volume of an Input's G Bus      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeBusMixerM","Description":"Set Volume of an Input's Master Bus      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannel1","Description":"When using SeparateMono on an Audio Input, this can be used to set channel volumes independently.      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannel2","Description":"When using SeparateMono on an Audio Input, this can be used to set channel volumes independently.      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer","Description":"Set Volume of an Input's sub channel (1 to 16)      Value = Channel,Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer1","Description":"Set Volume of an Input's sub channel 1      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer10","Description":"Set Volume of an Input's sub channel 10      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer11","Description":"Set Volume of an Input's sub channel 11      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer12","Description":"Set Volume of an Input's sub channel 12      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer13","Description":"Set Volume of an Input's sub channel 13      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer14","Description":"Set Volume of an Input's sub channel 14      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer15","Description":"Set Volume of an Input's sub channel 15      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer16","Description":"Set Volume of an Input's sub channel 16      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer2","Description":"Set Volume of an Input's sub channel 2      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer3","Description":"Set Volume of an Input's sub channel 3      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer4","Description":"Set Volume of an Input's sub channel 4      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer5","Description":"Set Volume of an Input's sub channel 5      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer6","Description":"Set Volume of an Input's sub channel 6      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer7","Description":"Set Volume of an Input's sub channel 7      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer8","Description":"Set Volume of an Input's sub channel 8      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeChannelMixer9","Description":"Set Volume of an Input's sub channel 9      Value = Volume 0-100","Parameters":["Value","Input"]},{"Name":"SetVolumeFade","Description":"Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds","Parameters":["Value","Input"]},{"Name":"Solo","Description":"","Parameters":["Input"]},{"Name":"SoloAllOff","Description":"Turn off Solo for all Inputs and Busses","Parameters":null},{"Name":"SoloOff","Description":"","Parameters":["Input"]},{"Name":"SoloOn","Description":"","Parameters":["Input"]},{"Name":"SoloPFL","Description":"Toggle between AFL or PFL mode for Solo","Parameters":["Input"]},{"Name":"SoloPFLOff","Description":"Turn off PFL mode for Solo","Parameters":["Input"]},{"Name":"SoloPFLOn","Description":"Turn on PFL mode for Solo","Parameters":["Input"]},{"Name":"CutDirect","Description":"Cuts the input directly to Output without changing Preview","Parameters":["Input"]},{"Name":"FadeToBlack","Description":"Toggle FTB On/Off","Parameters":null},{"Name":"QuickPlay","Description":"","Parameters":["Input"]},{"Name":"SetFader","Description":"Set Master Fader T-Bar, 255 will cut to Preview      Value = Fader 0-255","Parameters":["Value"]},{"Name":"SetStingerGTInput1","Description":"Assign GT Input as animation source for Stinger 1","Parameters":["Input"]},{"Name":"SetStingerGTInput2","Description":"Assign GT Input as animation source for Stinger 2","Parameters":["Input"]},{"Name":"SetStingerGTInput3","Description":"Assign GT Input as animation source for Stinger 3","Parameters":["Input"]},{"Name":"SetStingerGTInput4","Description":"Assign GT Input as animation source for Stinger 4","Parameters":["Input"]},{"Name":"SetTransitionDuration1","Description":"Change Transition Duration for Button 1      Value = Duration MS","Parameters":["Value"]},{"Name":"SetTransitionDuration2","Description":"Change Transition Duration for Button 2      Value = Duration MS","Parameters":["Value"]},{"Name":"SetTransitionDuration3","Description":"Change Transition Duration for Button 3      Value = Duration MS","Parameters":["Value"]},{"Name":"SetTransitionDuration4","Description":"Change Transition Duration for Button 4      Value = Duration MS","Parameters":["Value"]},{"Name":"SetTransitionEffect1","Description":"Change Transition for Button 1      Value = Transition","Parameters":["Value"]},{"Name":"SetTransitionEffect2","Description":"Change Transition for Button 2      Value = Transition","Parameters":["Value"]},{"Name":"SetTransitionEffect3","Description":"Change Transition for Button 3      Value = Transition","Parameters":["Value"]},{"Name":"SetTransitionEffect4","Description":"Change Transition for Button 4      Value = Transition","Parameters":["Value"]},{"Name":"Stinger1","Description":"","Parameters":["Input","Mix"]},{"Name":"Stinger2","Description":"","Parameters":["Input","Mix"]},{"Name":"Stinger3","Description":"","Parameters":["Input","Mix"]},{"Name":"Stinger4","Description":"","Parameters":["Input","Mix"]},{"Name":"Transition1","Description":"Clicks one of the four Transition buttons in the main vMix window.","Parameters":null},{"Name":"Transition2","Description":"","Parameters":null},{"Name":"Transition3","Description":"","Parameters":null},{"Name":"Transition4","Description":"","Parameters":null},{"Name":"Fullscreen","Description":"Toggles Fullscreen On or Off","Parameters":null},{"Name":"FullscreenOff","Description":"","Parameters":null},{"Name":"FullscreenOn","Description":"","Parameters":null},{"Name":"SetOutput2","Description":"Change what is displayed on Output 2.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input","Parameters":["Value","Input","Mix"]},{"Name":"SetOutput3","Description":"Change what is displayed on Output 3.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input","Parameters":["Value","Input","Mix"]},{"Name":"SetOutput4","Description":"Change what is displayed on Output 4.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input","Parameters":["Value","Input","Mix"]},{"Name":"SetOutputExternal2","Description":"Change what is displayed on the External2 output.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input","Parameters":["Value","Input","Mix"]},{"Name":"SetOutputFullscreen","Description":"Change what is displayed on the Fullscreen output.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input","Parameters":["Value","Input","Mix"]},{"Name":"SetOutputFullscreen2","Description":"Change what is displayed on the Fullscreen2 output.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input","Parameters":["Value","Input","Mix"]},{"Name":"Snapshot","Description":"Create a snapshot image of the current Output. Optional Value specifies save Filename, otherwise a save file window will appear. Filename can specify date, for example mysnapshot {0:dd MMM yyyy}.jpg      Value = Value","Parameters":["Value"]},{"Name":"SnapshotInput","Description":"Create a snapshot image of the selected Input. Optional Value specifies save Filename, otherwise a save file window will appear. Filename can specify date, for example mysnapshot {0:dd MMM yyyy}.jpg      Value = Value","Parameters":["Value","Input"]},{"Name":"StartExternal","Description":"","Parameters":null},{"Name":"StartMultiCorder","Description":"","Parameters":null},{"Name":"StartRecording","Description":"","Parameters":null},{"Name":"StartSRTOutput","Description":"Optional output number starting from 0. Leave blank to control Output 1 only.      Value = Output","Parameters":["Value"]},{"Name":"StartStopExternal","Description":"","Parameters":null},{"Name":"StartStopMultiCorder","Description":"","Parameters":null},{"Name":"StartStopRecording","Description":"","Parameters":null},{"Name":"StartStopSRTOutput","Description":"Optional output number starting from 0. Leave blank to control Output 1 only.      Value = Output","Parameters":["Value"]},{"Name":"StartStopStreaming","Description":"Optional stream number starting from 0. Leave blank to control all streams.      Value = Stream","Parameters":["Value"]},{"Name":"StartStreaming","Description":"Optional stream number starting from 0. Leave blank to control all streams.      Value = Stream","Parameters":["Value"]},{"Name":"StopExternal","Description":"","Parameters":null},{"Name":"StopMultiCorder","Description":"","Parameters":null},{"Name":"StopRecording","Description":"","Parameters":null},{"Name":"StopSRTOutput","Description":"Optional output number starting from 0. Leave blank to control Output 1 only.      Value = Output","Parameters":["Value"]},{"Name":"StopStreaming","Description":"Optional stream number starting from 0. Leave blank to control all streams.      Value = Stream","Parameters":["Value"]},{"Name":"StreamingSetKey","Description":"Set Key on Custom RTMP Stream. Optional stream number starting from 0 at start followed by comma, e.g 0,mystreamkey      Value = Stream","Parameters":["Value"]},{"Name":"StreamingSetPassword","Description":"Set Password on Custom RTMP Stream. Optional stream number starting from 0 at start followed by comma, e.g 0,password      Value = Stream","Parameters":["Value"]},{"Name":"StreamingSetURL","Description":"Set URL on Custom RTMP Stream. Optional stream number starting from 0 at start followed by comma, e.g 0,rtmp://myurl/      Value = Stream","Parameters":["Value"]},{"Name":"StreamingSetUsername","Description":"Set Username on Custom RTMP Stream. Optional stream number starting from 0 at start followed by comma, e.g 0,username      Value = Stream","Parameters":["Value"]},{"Name":"WriteDurationToRecordingLog","Description":"Write current recording duration to log file with optional tag text Value.      Value = Tag Text","Parameters":["Value"]},{"Name":"AdjustCountdown","Description":"Seconds to add or subtract from current Countdown time      Value = Seconds","Parameters":["Value","Input"]},{"Name":"ChangeCountdown","Description":"Change countdown time according to Value as hh:mm:ss (00:00:00)      Value = Time 00:00:00","Parameters":["Value","Input"]},{"Name":"NextTitlePreset","Description":"","Parameters":["Input"]},{"Name":"PauseCountdown","Description":"Pause or Resume Countdown or if complete, Start from beginning.","Parameters":["Input"]},{"Name":"PauseRender","Description":"Freeze Title Input while making multiple updates","Parameters":["Input"]},{"Name":"PreviousTitlePreset","Description":"","Parameters":["Input"]},{"Name":"ResumeRender","Description":"Resume Title Input rendering after making multiple updates","Parameters":["Input"]},{"Name":"SelectTitlePreset","Description":"Value = Preset Index","Parameters":["Value","Input"]},{"Name":"SetColor","Description":"Change Color in Title using HTML #xxxxxxxx format.      SelectedIndex or SelectedName can be used to select object.      Value = Color","Parameters":["Value","Input"]},{"Name":"SetCountdown","Description":"Set countdown duration according to Value as hh:mm:ss (00:00:00)      Value = Duration 00:00:00","Parameters":["Value","Input"]},{"Name":"SetImage","Description":"Change Image in Title according to Filename or empty to clear.      SelectedIndex or SelectedName can be used to select image.      Value = Filename","Parameters":["Value","Input"]},{"Name":"SetImageVisible","Description":"Toggle Image Visibility in Title      SelectedIndex or SelectedName can be used to select image.","Parameters":["Input"]},{"Name":"SetImageVisibleOff","Description":"Hide Image in Title      SelectedIndex or SelectedName can be used to select image.","Parameters":["Input"]},{"Name":"SetImageVisibleOn","Description":"Show Image in Title      SelectedIndex or SelectedName can be used to select image.","Parameters":["Input"]},{"Name":"SetText","Description":"Change Text in Title according to Value parameter.      SelectedIndex or SelectedName can be used to select Text Field      Value = Text","Parameters":["Value","Input"]},{"Name":"SetTextColour","Description":"Change Colour of Text in Title in HTML format (#xxxxxx)      Value = Colour","Parameters":["Value","Input"]},{"Name":"SetTextVisible","Description":"Toggle Text Visibility in Title      SelectedIndex or SelectedName can be used to select text field.","Parameters":["Input"]},{"Name":"SetTextVisibleOff","Description":"Hide Text in Title      SelectedIndex or SelectedName can be used to select text field.","Parameters":["Input"]},{"Name":"SetTextVisibleOn","Description":"Show Text in Title      SelectedIndex or SelectedName can be used to select text field.","Parameters":["Input"]},{"Name":"SetTickerSpeed","Description":"Change Ticker Speed.      SelectedIndex or SelectedName can be used to select ticker field.      Value = Speed 0-1000","Parameters":["Value","Input"]},{"Name":"StartCountdown","Description":"","Parameters":["Input"]},{"Name":"StopCountdown","Description":"Stop and Reset Countdown","Parameters":["Input"]},{"Name":"SuspendCountdown","Description":"Pause Countdown Only","Parameters":["Input"]},{"Name":"TitleBeginAnimation","Description":"Value = Animation","Parameters":["Value","Input"]},{"Name":"ActiveInput","Description":"Send to Output the selected Input","Parameters":["Input","Mix"]},{"Name":"AddInput","Description":"Create a new Input based on information provided in Value.      Video|c:\\path\\to\\video.avi      Image|c:\\path\\to\\image.jpg      Photos|c:\\path\\to\\folder      Title|c:\\path\\to\\title.gtzip      VideoList|c:\\path\\to\\playlist.m3u      Colour|HTMLColor      AudioFile|c:\\path\\to\\audio.wav      Flash|c:\\path\\to\\flash.swf      PowerPoint|c:\\path\\to\\powerpoint.pptx      Value = Type|Filename","Parameters":["Value"]},{"Name":"AutoPauseOff","Description":"","Parameters":["Input"]},{"Name":"AutoPauseOn","Description":"","Parameters":["Input"]},{"Name":"AutoPlayFirst","Description":"Toggle automatically playing first item in a List with Transition","Parameters":["Input"]},{"Name":"AutoPlayFirstOff","Description":"Turn Off automatically playing first item in a List with Transition","Parameters":["Input"]},{"Name":"AutoPlayFirstOn","Description":"Turn On automatically playing first item in a List with Transition","Parameters":["Input"]},{"Name":"AutoPlayNext","Description":"Toggle automatically playing next item in a List","Parameters":["Input"]},{"Name":"AutoPlayNextOff","Description":"Turn Off automatically playing next item in a List","Parameters":["Input"]},{"Name":"AutoPlayNextOn","Description":"Turn On automatically playing next item in a List","Parameters":["Input"]},{"Name":"AutoPlayOff","Description":"","Parameters":["Input"]},{"Name":"AutoPlayOn","Description":"","Parameters":["Input"]},{"Name":"AutoRestartOff","Description":"","Parameters":["Input"]},{"Name":"AutoRestartOn","Description":"","Parameters":["Input"]},{"Name":"ColourCorrectionAuto","Description":"Basic Auto Colour Correction.","Parameters":["Input"]},{"Name":"ColourCorrectionReset","Description":"Reset Colour Correction to Default Values.","Parameters":["Input"]},{"Name":"CreateVirtualInput","Description":"Create a new Virtual Input from the specified Input.","Parameters":["Input"]},{"Name":"DeinterlaceOff","Description":"","Parameters":["Input"]},{"Name":"DeinterlaceOn","Description":"","Parameters":["Input"]},{"Name":"Effect1","Description":"Toggle Effect 1 On/Off","Parameters":["Input"]},{"Name":"Effect1Off","Description":"Turn Effect 1 Off","Parameters":["Input"]},{"Name":"Effect1On","Description":"Turn Effect 1 On","Parameters":["Input"]},{"Name":"Effect2","Description":"Toggle Effect 2 On/Off","Parameters":["Input"]},{"Name":"Effect2Off","Description":"Turn Effect 2 Off","Parameters":["Input"]},{"Name":"Effect2On","Description":"Turn Effect 2 On","Parameters":["Input"]},{"Name":"Effect3","Description":"Toggle Effect 3 On/Off","Parameters":["Input"]},{"Name":"Effect3Off","Description":"Turn Effect 3 Off","Parameters":["Input"]},{"Name":"Effect3On","Description":"Turn Effect 3 On","Parameters":["Input"]},{"Name":"Effect4","Description":"Toggle Effect 4 On/Off","Parameters":["Input"]},{"Name":"Effect4Off","Description":"Turn Effect 4 Off","Parameters":["Input"]},{"Name":"Effect4On","Description":"Turn Effect 4 On","Parameters":["Input"]},{"Name":"InputPreviewHide","Description":"Hides large preview of input","Parameters":["Input"]},{"Name":"InputPreviewShow","Description":"Shows large preview of input","Parameters":["Input"]},{"Name":"InputPreviewShowHide","Description":"Toggles large preview of input","Parameters":["Input"]},{"Name":"LayerOff","Description":"Turn Off Layer For Input At Index (starting from 1)      Value = Index","Parameters":["Value","Input"]},{"Name":"LayerOn","Description":"Turn On Layer For Input At Index (starting from 1)      Value = Index","Parameters":["Value","Input"]},{"Name":"LayerOnOff","Description":"Toggle On/Off Layer For Input At Index (starting from 1)      Value = Index","Parameters":["Value","Input"]},{"Name":"ListAdd","Description":"Add Filename to List      Value = Filename","Parameters":["Value","Input"]},{"Name":"ListExport","Description":"Export List as M3U to Filename      Value = Filename","Parameters":["Value","Input"]},{"Name":"ListPlayOut","Description":"","Parameters":["Input"]},{"Name":"ListRemove","Description":"Remove from List by Index starting from 1      Value = Index","Parameters":["Value","Input"]},{"Name":"ListRemoveAll","Description":"Remove all items from List","Parameters":["Input"]},{"Name":"ListShowHide","Description":"","Parameters":["Input"]},{"Name":"ListShuffle","Description":"Shuffle (randomize) List","Parameters":["Input"]},{"Name":"LivePlayPause","Description":"","Parameters":["Input"]},{"Name":"Loop","Description":"Toggle Loop on Input","Parameters":["Input"]},{"Name":"LoopOff","Description":"","Parameters":["Input"]},{"Name":"LoopOn","Description":"","Parameters":["Input"]},{"Name":"MarkIn","Description":"","Parameters":["Input"]},{"Name":"MarkOut","Description":"","Parameters":["Input"]},{"Name":"MarkReset","Description":"","Parameters":["Input"]},{"Name":"MarkResetIn","Description":"","Parameters":["Input"]},{"Name":"MarkResetOut","Description":"","Parameters":["Input"]},{"Name":"MirrorOff","Description":"","Parameters":["Input"]},{"Name":"MirrorOn","Description":"","Parameters":["Input"]},{"Name":"MoveInput","Description":"Value = Number","Parameters":["Value","Input"]},{"Name":"MoveLayer","Description":"Move Layer in Input according to Value parameter.      Example: 1,2 moves Layer1 to Layer2      Value = FromIndex,ToIndex","Parameters":["Value","Input"]},{"Name":"NextItem","Description":"Move to next item in List","Parameters":["Input"]},{"Name":"NextPicture","Description":"Move to Next Picture for Photo and PowerPoint Inputs","Parameters":["Input"]},{"Name":"Pause","Description":"","Parameters":["Input"]},{"Name":"Play","Description":"","Parameters":["Input"]},{"Name":"PlayPause","Description":"","Parameters":["Input"]},{"Name":"PreviewInput","Description":"Send to Preview the selected Input","Parameters":["Input","Mix"]},{"Name":"PreviewInputNext","Description":"Send to Preview the next Input","Parameters":null},{"Name":"PreviewInputPrevious","Description":"Send to Preview the previous Input","Parameters":null},{"Name":"PreviousItem","Description":"Move to previous item in List","Parameters":["Input"]},{"Name":"PreviousPicture","Description":"Move to Previous Picture for Photo and PowerPoint Inputs","Parameters":["Input"]},{"Name":"RemoveInput","Description":"","Parameters":["Input"]},{"Name":"ResetInput","Description":"","Parameters":["Input"]},{"Name":"Restart","Description":"Restart selected Input","Parameters":["Input"]},{"Name":"SaveVideoDelay","Description":"Save video clip from Video Delay according to Duration in milliseconds","Parameters":["Input","Duration"]},{"Name":"SelectCategory","Description":"Change to Category according to Value (All,Red,Green,Orange,Purple,Aqua,Blue,Custom1-16,Search)      Value = Category","Parameters":["Value"]},{"Name":"SelectIndex","Description":"Photos,List: Selects item in List according to Value starting from number 1      Virtual Set: Zooms to selected preset using the current speed settings      Title: Starts Page animation according to Value starting from number 1      Value = Index","Parameters":["Value","Input"]},{"Name":"SetAlpha","Description":"Set Input transparency according to Value. 0 is transparent, 255 is opaque      Value = Alpha 0-255","Parameters":["Value","Input"]},{"Name":"SetCCGainB","Description":"Change Gain B level of Input.      1=Original      Value = Value 0-2","Parameters":["Value","Input"]},{"Name":"SetCCGainG","Description":"Change Gain G level of Input.      1=Original      Value = Value 0-2","Parameters":["Value","Input"]},{"Name":"SetCCGainR","Description":"Change Gain R level of Input.      1=Original      Value = Value 0-2","Parameters":["Value","Input"]},{"Name":"SetCCGainRGB","Description":"Change Gain RGB level of Input.      1=Original      Value = Value 0-2","Parameters":["Value","Input"]},{"Name":"SetCCGainY","Description":"Change Gain Y level of Input.      1=Original      Value = Value 0-2","Parameters":["Value","Input"]},{"Name":"SetCCGammaB","Description":"Change Gamma B level of Input.      0=Original      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCCGammaG","Description":"Change Gamma G level of Input.      0=Original      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCCGammaR","Description":"Change Gamma R level of Input.      0=Original      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCCGammaRGB","Description":"Change Gamma RGB level of Input.      0=Original      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCCGammaY","Description":"Change Gamma Y level of Input.      0=Original      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCCHue","Description":"Change Hue level of Input.      0=Original      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCCLiftB","Description":"Change Lift B level of Input.      0=Original      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCCLiftG","Description":"Change Lift G level of Input.      0=Original      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCCLiftR","Description":"Change Lift R level of Input.      0=Original      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCCLiftRGB","Description":"Change Lift RGB level of Input.      0=Original      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCCLiftY","Description":"Change Lift Y level of Input.      0=Original      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCCSaturation","Description":"Change Saturation level of Input.      0=Original, -1=Greyscale      Value = Value -1-1","Parameters":["Value","Input"]},{"Name":"SetCrop","Description":"Change current Crop value of Input.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetCropX1","Description":"Change current Crop X1 value of Input.      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetCropX2","Description":"Change current Crop X2 value of Input.      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetCropY1","Description":"Change current Crop Y1 value of Input.      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetCropY2","Description":"Change current Crop Y2 value of Input.      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetDynamicInput1","Description":"Set Dynamic Input from Input Name or Number      Value = Input","Parameters":["Value"]},{"Name":"SetDynamicInput2","Description":"Set Dynamic Input from Input Name or Number      Value = Input","Parameters":["Value"]},{"Name":"SetDynamicInput3","Description":"Set Dynamic Input from Input Name or Number      Value = Input","Parameters":["Value"]},{"Name":"SetDynamicInput4","Description":"Set Dynamic Input from Input Name or Number      Value = Input","Parameters":["Value"]},{"Name":"SetEffect1Strength","Description":"Set Input 1 Effect Strength      Value = Value 0-1","Parameters":["Value","Input"]},{"Name":"SetEffect2Strength","Description":"Set Input 2 Effect Strength      Value = Value 0-1","Parameters":["Value","Input"]},{"Name":"SetEffect3Strength","Description":"Set Input 3 Effect Strength      Value = Value 0-1","Parameters":["Value","Input"]},{"Name":"SetEffect4Strength","Description":"Set Input 4 Effect Strength      Value = Value 0-1","Parameters":["Value","Input"]},{"Name":"SetFrameDelay","Description":"Set the delay in frames      Value = Frames","Parameters":["Value","Input"]},{"Name":"SetInputName","Description":"Set the Display Name of the Input      Value = Name","Parameters":["Value","Input"]},{"Name":"SetLayer","Description":"Change Layer in Input according to Value parameter.      Example: 1,2 changes Layer1 to Input2      Value = Index,Input","Parameters":["Value","Input"]},{"Name":"SetLayer10Crop","Description":"Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetLayer10CropX1","Description":"Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer10CropX2","Description":"Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer10CropY1","Description":"Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer10CropY2","Description":"Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer10Height","Description":"Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer10PanX","Description":"Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer10PanY","Description":"Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer10Rectangle","Description":"Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height","Parameters":["Value","Input"]},{"Name":"SetLayer10Width","Description":"Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer10X","Description":"Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer10Y","Description":"Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer10Zoom","Description":"Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SetLayer1Crop","Description":"Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetLayer1CropX1","Description":"Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer1CropX2","Description":"Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer1CropY1","Description":"Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer1CropY2","Description":"Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer1Height","Description":"Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer1PanX","Description":"Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer1PanY","Description":"Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer1Rectangle","Description":"Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height","Parameters":["Value","Input"]},{"Name":"SetLayer1Width","Description":"Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer1X","Description":"Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer1Y","Description":"Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer1Zoom","Description":"Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SetLayer2Crop","Description":"Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetLayer2CropX1","Description":"Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer2CropX2","Description":"Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer2CropY1","Description":"Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer2CropY2","Description":"Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer2Height","Description":"Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer2PanX","Description":"Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer2PanY","Description":"Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer2Rectangle","Description":"Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height","Parameters":["Value","Input"]},{"Name":"SetLayer2Width","Description":"Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer2X","Description":"Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer2Y","Description":"Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer2Zoom","Description":"Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SetLayer3Crop","Description":"Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetLayer3CropX1","Description":"Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer3CropX2","Description":"Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer3CropY1","Description":"Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer3CropY2","Description":"Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer3Height","Description":"Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer3PanX","Description":"Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer3PanY","Description":"Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer3Rectangle","Description":"Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height","Parameters":["Value","Input"]},{"Name":"SetLayer3Width","Description":"Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer3X","Description":"Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer3Y","Description":"Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer3Zoom","Description":"Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SetLayer4Crop","Description":"Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetLayer4CropX1","Description":"Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer4CropX2","Description":"Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer4CropY1","Description":"Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer4CropY2","Description":"Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer4Height","Description":"Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer4PanX","Description":"Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer4PanY","Description":"Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer4Rectangle","Description":"Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height","Parameters":["Value","Input"]},{"Name":"SetLayer4Width","Description":"Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer4X","Description":"Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer4Y","Description":"Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer4Zoom","Description":"Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SetLayer5Crop","Description":"Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetLayer5CropX1","Description":"Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer5CropX2","Description":"Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer5CropY1","Description":"Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer5CropY2","Description":"Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer5Height","Description":"Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer5PanX","Description":"Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer5PanY","Description":"Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer5Rectangle","Description":"Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height","Parameters":["Value","Input"]},{"Name":"SetLayer5Width","Description":"Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer5X","Description":"Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer5Y","Description":"Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer5Zoom","Description":"Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SetLayer6Crop","Description":"Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetLayer6CropX1","Description":"Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer6CropX2","Description":"Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer6CropY1","Description":"Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer6CropY2","Description":"Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer6Height","Description":"Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer6PanX","Description":"Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer6PanY","Description":"Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer6Rectangle","Description":"Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height","Parameters":["Value","Input"]},{"Name":"SetLayer6Width","Description":"Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer6X","Description":"Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer6Y","Description":"Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer6Zoom","Description":"Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SetLayer7Crop","Description":"Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetLayer7CropX1","Description":"Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer7CropX2","Description":"Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer7CropY1","Description":"Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer7CropY2","Description":"Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer7Height","Description":"Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer7PanX","Description":"Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer7PanY","Description":"Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer7Rectangle","Description":"Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height","Parameters":["Value","Input"]},{"Name":"SetLayer7Width","Description":"Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer7X","Description":"Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer7Y","Description":"Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer7Zoom","Description":"Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SetLayer8Crop","Description":"Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetLayer8CropX1","Description":"Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer8CropX2","Description":"Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer8CropY1","Description":"Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer8CropY2","Description":"Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer8Height","Description":"Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer8PanX","Description":"Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer8PanY","Description":"Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer8Rectangle","Description":"Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height","Parameters":["Value","Input"]},{"Name":"SetLayer8Width","Description":"Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer8X","Description":"Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer8Y","Description":"Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer8Zoom","Description":"Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SetLayer9Crop","Description":"Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetLayer9CropX1","Description":"Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer9CropX2","Description":"Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer9CropY1","Description":"Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer9CropY2","Description":"Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayer9Height","Description":"Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer9PanX","Description":"Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer9PanY","Description":"Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayer9Rectangle","Description":"Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height","Parameters":["Value","Input"]},{"Name":"SetLayer9Width","Description":"Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer9X","Description":"Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer9Y","Description":"Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayer9Zoom","Description":"Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SetLayerAnimated","Description":"Change Layer Index to Input. Animate if input exists in another layer.      Example: 1,2,1000 changes Layer1 to Input2.      Value = Index,Input,DurationMilliseconds","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicCrop","Description":"Change current Crop value of Input Layer from DynamicValue1 (1-10).      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicCropX1","Description":"Change current Crop X1 value of Input Layer from DynamicValue1 (1-10).      0=No Crop, 1=Full Crop      Value = X1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicCropX2","Description":"Change current Crop X2 value of Input Layer from DynamicValue1 (1-10).      1=No Crop, 0=Full Crop      Value = X2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicCropY1","Description":"Change current Crop Y1 value of Input Layer from DynamicValue1 (1-10).      0=No Crop, 1=Full Crop      Value = Y1 0-1","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicCropY2","Description":"Change current Crop Y2 value of Input Layer from DynamicValue1 (1-10).      1=No Crop, 0=Full Crop      Value = Y2 0-1","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicHeight","Description":"Change current Height value of Input Layer from DynamicValue1 (1-10).      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicPanX","Description":"Change current PanX value of Input Layer from DynamicValue1 (1-10).      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicPanY","Description":"Change current PanY value of Input Layer from DynamicValue1 (1-10).      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicRectangle","Description":"Change current Rectangle values of Input Layer from DynamicValue1 (1-10) in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicWidth","Description":"Change current Width value of Input Layer from DynamicValue1 (1-10).      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicX","Description":"Change current X value of Input Layer from DynamicValue1 (1-10).      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicY","Description":"Change current Y value of Input Layer from DynamicValue1 (1-10).      In pixels based on preset resolution      Value = Pixels -4096-4096","Parameters":["Value","Input"]},{"Name":"SetLayerDynamicZoom","Description":"Change current Zoom level of Input Layer from DynamicValue1 (1-10).      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SetPanX","Description":"Change current PanX value of Input.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetPanY","Description":"Change current PanY value of Input.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2","Parameters":["Value","Input"]},{"Name":"SetPictureEffect","Description":"Set transition effect for Photos and PowerPoint Inputs (Fade, Zoom, etc)      Value = Transition","Parameters":["Value","Input"]},{"Name":"SetPictureEffectDuration","Description":"Set duration of transition effect in Milliseconds      Value = Duration MS","Parameters":["Value","Input"]},{"Name":"SetPictureTransition","Description":"Set transition time between Photos and PowerPoint slides in Seconds      Value = Seconds","Parameters":["Value","Input"]},{"Name":"SetPosition","Description":"Set Position of selected Input according to Value in Milliseconds      Value = Milliseconds","Parameters":["Value","Input"]},{"Name":"SetRate","Description":"Set Playback speed/rate for Videos and Video Delays      0.5=50%,1=100%,2=200% etc      Value = Speed 0.1-4","Parameters":["Value","Input"]},{"Name":"SetRateSlowMotion","Description":"Set Slow Motion speed for Instant Replay      0.5=50%,1=100% etc      Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"SetZoom","Description":"Change current Zoom level of Input.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5","Parameters":["Value","Input"]},{"Name":"SharpenOff","Description":"","Parameters":["Input"]},{"Name":"SharpenOn","Description":"","Parameters":["Input"]},{"Name":"SwapLayerAnimated","Description":"Animate swapping the Layers in Input according to Value parameter.      Example: 1,2,1000 swaps Layer1 and Layer2 over 1000 milliseconds.      Value = FromIndex,ToIndex,DurationMilliseconds","Parameters":["Value","Input"]},{"Name":"VideoCallAudioSource","Description":"Master,Headphones,BusA,BusB,BusC,BusD,BusE,BusF,BusG      Value = Source","Parameters":["Value","Input"]},{"Name":"VideoCallConnect","Description":"Value = Name,Password","Parameters":["Value","Input"]},{"Name":"VideoCallReconnect","Description":"","Parameters":["Input"]},{"Name":"VideoCallVideoSource","Description":"Output1,Output2,Output3,Output4      Value = Source","Parameters":["Value","Input"]},{"Name":"VideoDelayStartRecording","Description":"Start Video Delay Recording","Parameters":["Input","Duration"]},{"Name":"VideoDelayStartStopRecording","Description":"Toggle Video Delay Recording","Parameters":["Input","Duration"]},{"Name":"VideoDelayStopRecording","Description":"Stop Video Delay Recording","Parameters":["Input","Duration"]},{"Name":"WaitForCompletion","Description":"Wait for a Video Input to reach the end of playback.","Parameters":["Input","Duration"]},{"Name":"ZoomJoinMeeting","Description":"Value = MeetingID,Password","Parameters":["Value","Input"]},{"Name":"ZoomMuteSelf","Description":"","Parameters":["Input"]},{"Name":"ZoomSelectParticipantByName","Description":"Value = Name","Parameters":["Value","Input"]},{"Name":"ZoomUnMuteSelf","Description":"","Parameters":["Input"]},{"Name":"MoveMultiViewOverlay","Description":"Move Overlay in Input MultiView according to Value parameter.      Example: 1,2 moves Overlay1 to Overlay2      Value = FromIndex,ToIndex","Parameters":["Value","Input"]},{"Name":"MultiViewOverlay","Description":"Toggle On/Off MultiView Overlay For Input At Index (starting from 1)      Value = Index","Parameters":["Value","Input"]},{"Name":"MultiViewOverlayOff","Description":"Turn Off MultiView Overlay For Input At Index (starting from 1)      Value = Index","Parameters":["Value","Input"]},{"Name":"MultiViewOverlayOn","Description":"Turn On MultiView Overlay For Input At Index (starting from 1)      Value = Index","Parameters":["Value","Input"]},{"Name":"OverlayInput1","Description":"Toggle Overlay1 On/Off with selected Input using configured Transition","Parameters":["Input","Mix"]},{"Name":"OverlayInput1In","Description":"Transition Out to Overlay1 with selected Input","Parameters":["Input","Mix"]},{"Name":"OverlayInput1Last","Description":"Toggle Overlay1 On/Off with last used Input on this channel","Parameters":["Mix"]},{"Name":"OverlayInput1Off","Description":"Immediately switch Overlay1 Off (Cut)","Parameters":null},{"Name":"OverlayInput1Out","Description":"Transition Out Overlay1","Parameters":null},{"Name":"OverlayInput1Zoom","Description":"Zooms PIP Overlay to fill Fullscreen and vice versa","Parameters":null},{"Name":"OverlayInput2","Description":"","Parameters":["Input","Mix"]},{"Name":"OverlayInput2In","Description":"","Parameters":["Input","Mix"]},{"Name":"OverlayInput2Last","Description":"Toggle Overlay2 On/Off with last used Input on this channel","Parameters":["Mix"]},{"Name":"OverlayInput2Off","Description":"","Parameters":null},{"Name":"OverlayInput2Out","Description":"","Parameters":null},{"Name":"OverlayInput2Zoom","Description":"","Parameters":null},{"Name":"OverlayInput3","Description":"","Parameters":["Input","Mix"]},{"Name":"OverlayInput3In","Description":"","Parameters":["Input","Mix"]},{"Name":"OverlayInput3Last","Description":"Toggle Overlay3 On/Off with last used Input on this channel","Parameters":["Mix"]},{"Name":"OverlayInput3Off","Description":"","Parameters":null},{"Name":"OverlayInput3Out","Description":"","Parameters":null},{"Name":"OverlayInput3Zoom","Description":"","Parameters":null},{"Name":"OverlayInput4","Description":"","Parameters":["Input","Mix"]},{"Name":"OverlayInput4In","Description":"","Parameters":["Input","Mix"]},{"Name":"OverlayInput4Last","Description":"Toggle Overlay4 On/Off with last used Input on this channel","Parameters":["Mix"]},{"Name":"OverlayInput4Off","Description":"","Parameters":null},{"Name":"OverlayInput4Out","Description":"","Parameters":null},{"Name":"OverlayInput4Zoom","Description":"","Parameters":null},{"Name":"OverlayInputAllOff","Description":"Immediately switch all Overlays Off","Parameters":null},{"Name":"PreviewOverlayInput1","Description":"Preview Overlay1 using the selected Input","Parameters":["Input"]},{"Name":"PreviewOverlayInput2","Description":"","Parameters":["Input"]},{"Name":"PreviewOverlayInput3","Description":"","Parameters":["Input"]},{"Name":"PreviewOverlayInput4","Description":"","Parameters":["Input"]},{"Name":"SetMultiViewOverlay","Description":"Change Layer in Input MultiView according to Value parameter.      Example: 1,2 changes Layer 1 to Input2      Value = Index,Input","Parameters":["Value","Input"]},{"Name":"NextPlayListEntry","Description":"Move to Next Item in a running PlayList","Parameters":null},{"Name":"PreviousPlayListEntry","Description":"Move to Previous Item in a running PlayList","Parameters":null},{"Name":"SelectPlayList","Description":"Open PlayList with Name matching Value      Value = PlayList","Parameters":["Value"]},{"Name":"StartPlayList","Description":"","Parameters":null},{"Name":"StopPlayList","Description":"","Parameters":null},{"Name":"ScriptStart","Description":"Value = Script Name","Parameters":["Value"]},{"Name":"ScriptStartDynamic","Description":"Start a dynamic script using code specified as the Value.      Value = Code","Parameters":["Value"]},{"Name":"ScriptStop","Description":"Value = Script Name","Parameters":["Value"]},{"Name":"ScriptStopAll","Description":"","Parameters":null},{"Name":"ScriptStopDynamic","Description":"","Parameters":null},{"Name":"ReplayACamera1","Description":"","Parameters":null},{"Name":"ReplayACamera2","Description":"","Parameters":null},{"Name":"ReplayACamera3","Description":"","Parameters":null},{"Name":"ReplayACamera4","Description":"","Parameters":null},{"Name":"ReplayACamera5","Description":"","Parameters":null},{"Name":"ReplayACamera6","Description":"","Parameters":null},{"Name":"ReplayACamera7","Description":"","Parameters":null},{"Name":"ReplayACamera8","Description":"","Parameters":null},{"Name":"ReplayBCamera1","Description":"","Parameters":null},{"Name":"ReplayBCamera2","Description":"","Parameters":null},{"Name":"ReplayBCamera3","Description":"","Parameters":null},{"Name":"ReplayBCamera4","Description":"","Parameters":null},{"Name":"ReplayBCamera5","Description":"","Parameters":null},{"Name":"ReplayBCamera6","Description":"","Parameters":null},{"Name":"ReplayBCamera7","Description":"","Parameters":null},{"Name":"ReplayBCamera8","Description":"","Parameters":null},{"Name":"ReplayCamera1","Description":"","Parameters":null},{"Name":"ReplayCamera2","Description":"","Parameters":null},{"Name":"ReplayCamera3","Description":"","Parameters":null},{"Name":"ReplayCamera4","Description":"","Parameters":null},{"Name":"ReplayCamera5","Description":"","Parameters":null},{"Name":"ReplayCamera6","Description":"","Parameters":null},{"Name":"ReplayCamera7","Description":"","Parameters":null},{"Name":"ReplayCamera8","Description":"","Parameters":null},{"Name":"ReplayChangeDirection","Description":"","Parameters":["Channel"]},{"Name":"ReplayChangeSpeed","Description":"Value = Speed","Parameters":["Value","Channel"]},{"Name":"ReplayCopyLastEvent","Description":"Value = Event List 0-19","Parameters":["Value"]},{"Name":"ReplayCopySelectedEvent","Description":"Value = Event List 0-19","Parameters":["Value"]},{"Name":"ReplayDeleteLastEvent","Description":"","Parameters":["Channel"]},{"Name":"ReplayDeleteSelectedEvent","Description":"","Parameters":["Channel"]},{"Name":"ReplayDuplicateLastEvent","Description":"","Parameters":["Channel"]},{"Name":"ReplayDuplicateSelectedEvent","Description":"","Parameters":["Channel"]},{"Name":"ReplayExportLastEvent","Description":"Value = Folder","Parameters":["Value","Channel"]},{"Name":"ReplayFastBackward","Description":"1-30x      Value = Speed","Parameters":["Value","Channel"]},{"Name":"ReplayFastForward","Description":"1-30x      Value = Speed","Parameters":["Value","Channel"]},{"Name":"ReplayJumpFrames","Description":"Value = Frames","Parameters":["Value","Channel"]},{"Name":"ReplayJumpFramesFastOff","Description":"ReplayJumpFrames jumps 1 frame for each value instead of 1 second.","Parameters":["Channel"]},{"Name":"ReplayJumpFramesFastOn","Description":"ReplayJumpFrames jumps 1 second for each value instead of 1 frame.","Parameters":["Channel"]},{"Name":"ReplayJumpToNow","Description":"","Parameters":["Channel"]},{"Name":"ReplayJumpToSelectedInPoint","Description":"Set Position to In point of Selected Event.","Parameters":["Channel"]},{"Name":"ReplayJumpToSelectedOutPoint","Description":"Set Position to Out point of Selected Event.","Parameters":["Channel"]},{"Name":"ReplayLastEventCameraOff","Description":"Turns off the specified camera angle (1-8)      Value = Camera","Parameters":["Value"]},{"Name":"ReplayLastEventCameraOn","Description":"Turns on the specified camera angle (1-8)      Value = Camera","Parameters":["Value"]},{"Name":"ReplayLastEventSingleCameraOn","Description":"Turns on only the specified camera angle (1-8)      Value = Camera","Parameters":["Value"]},{"Name":"ReplayLive","Description":"","Parameters":null},{"Name":"ReplayLiveToggle","Description":"","Parameters":null},{"Name":"ReplayMarkCancel","Description":"","Parameters":null},{"Name":"ReplayMarkIn","Description":"","Parameters":null},{"Name":"ReplayMarkInLive","Description":"","Parameters":null},{"Name":"ReplayMarkInOut","Description":"Number of previous seconds to use when creating a new event.      Value = Seconds","Parameters":["Value"]},{"Name":"ReplayMarkInOutLive","Description":"Number of previous seconds to use when creating a new event.      Value = Seconds","Parameters":["Value"]},{"Name":"ReplayMarkInOutLiveFuture","Description":"Number of seconds into the future to use when creating a new event.      Value = Seconds","Parameters":["Value"]},{"Name":"ReplayMarkInOutRecorded","Description":"Number of previous seconds to use when creating a new event.      Value = Seconds","Parameters":["Value"]},{"Name":"ReplayMarkInRecorded","Description":"","Parameters":null},{"Name":"ReplayMarkInRecordedNow","Description":"","Parameters":null},{"Name":"ReplayMarkOut","Description":"","Parameters":null},{"Name":"ReplayMoveLastEvent","Description":"Value = Event List 0-19","Parameters":["Value"]},{"Name":"ReplayMoveSelectedEvent","Description":"Value = Event List 0-19","Parameters":["Value"]},{"Name":"ReplayMoveSelectedEventDown","Description":"","Parameters":null},{"Name":"ReplayMoveSelectedEventUp","Description":"","Parameters":null},{"Name":"ReplayMoveSelectedInPoint","Description":"Value = Frames","Parameters":["Value","Channel"]},{"Name":"ReplayMoveSelectedOutPoint","Description":"Value = Frames","Parameters":["Value","Channel"]},{"Name":"ReplayPause","Description":"","Parameters":["Channel"]},{"Name":"ReplayPlay","Description":"","Parameters":["Channel"]},{"Name":"ReplayPlayAllEvents","Description":"Play all Events in active list","Parameters":["Channel"]},{"Name":"ReplayPlayAllEventsToOutput","Description":"Play all Events in active list","Parameters":["Channel"]},{"Name":"ReplayPlayBackward","Description":"","Parameters":["Channel"]},{"Name":"ReplayPlayEvent","Description":"Value = Event Number where 0 is bottom of list 0-1000","Parameters":["Value","Channel"]},{"Name":"ReplayPlayEventsByID","Description":"Value = List of IDs","Parameters":["Value","Channel"]},{"Name":"ReplayPlayEventsByIDToOutput","Description":"Value = List of IDs","Parameters":["Value","Channel"]},{"Name":"ReplayPlayEventToOutput","Description":"Value = Event Number where 0 is bottom of list 0-1000","Parameters":["Value","Channel"]},{"Name":"ReplayPlayForward","Description":"","Parameters":["Channel"]},{"Name":"ReplayPlayLastEvent","Description":"","Parameters":["Channel"]},{"Name":"ReplayPlayLastEventToOutput","Description":"","Parameters":["Channel"]},{"Name":"ReplayPlayNext","Description":"","Parameters":["Channel"]},{"Name":"ReplayPlayPause","Description":"","Parameters":["Channel"]},{"Name":"ReplayPlayPrevious","Description":"","Parameters":["Channel"]},{"Name":"ReplayPlaySelectedEvent","Description":"","Parameters":["Channel"]},{"Name":"ReplayPlaySelectedEventToOutput","Description":"","Parameters":["Channel"]},{"Name":"ReplayRecorded","Description":"","Parameters":null},{"Name":"ReplayScrollSelectedEvent","Description":"Move back or forward through events list      Value = Count -10-10","Parameters":["Value"]},{"Name":"ReplaySelectAllEvents","Description":"Select all events in active channel.","Parameters":null},{"Name":"ReplaySelectChannelA","Description":"","Parameters":null},{"Name":"ReplaySelectChannelAB","Description":"","Parameters":null},{"Name":"ReplaySelectChannelB","Description":"","Parameters":null},{"Name":"ReplaySelectedEventCameraOff","Description":"Turns off the specified camera angle (1-8)      Value = Camera","Parameters":["Value"]},{"Name":"ReplaySelectedEventCameraOn","Description":"Turns on the specified camera angle (1-8)      Value = Camera","Parameters":["Value"]},{"Name":"ReplaySelectedEventSingleCameraOn","Description":"Turns on only the specified camera angle (1-8)      Value = Camera","Parameters":["Value"]},{"Name":"ReplaySelectEvents1","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents10","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents11","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents12","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents13","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents14","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents15","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents16","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents17","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents18","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents19","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents2","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents20","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents3","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents4","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents5","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents6","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents7","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents8","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectEvents9","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectFirstEvent","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectLastEvent","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectNextEvent","Description":"","Parameters":["Channel"]},{"Name":"ReplaySelectPreviousEvent","Description":"","Parameters":["Channel"]},{"Name":"ReplaySetAudioSource","Description":"Name as per dropdown box. e.g 'Camera1'      Value = AudioSource","Parameters":["Value"]},{"Name":"ReplaySetChannelAToBTimecode","Description":"Set A Timecode to B Timecode","Parameters":null},{"Name":"ReplaySetChannelAToBTimecodeAndCamera","Description":"Set A Timecode and Camera to B","Parameters":null},{"Name":"ReplaySetChannelBToATimecode","Description":"Set B Timecode to A Timecode","Parameters":null},{"Name":"ReplaySetChannelBToATimecodeAndCamera","Description":"Set B Timecode and Camera to A","Parameters":null},{"Name":"ReplaySetDirectionBackward","Description":"","Parameters":["Channel"]},{"Name":"ReplaySetDirectionForward","Description":"","Parameters":["Channel"]},{"Name":"ReplaySetLastEventText","Description":"Value = Text","Parameters":["Value"]},{"Name":"ReplaySetLastEventTextCamera","Description":"Changes the text of the specified angle (1-4), example: 3,angle3text      Value = Camera,Text","Parameters":["Value"]},{"Name":"ReplaySetSelectedEventText","Description":"Value = Text","Parameters":["Value"]},{"Name":"ReplaySetSelectedEventTextCamera","Description":"Changes the text of the specified angle (1-4), example: 3,angle3text      Value = Camera,Text","Parameters":["Value"]},{"Name":"ReplaySetSpeed","Description":"See SetRateSlowMotion      Value = Speed 0-1","Parameters":["Value","Channel"]},{"Name":"ReplaySetTimecode","Description":"Set position to Timecode in format yyyy-MM-ddTHH:mm:ss.fff      Value = Timecode","Parameters":["Value","Channel"]},{"Name":"ReplayShowHide","Description":"","Parameters":null},{"Name":"ReplayStartRecording","Description":"","Parameters":null},{"Name":"ReplayStartStopRecording","Description":"","Parameters":null},{"Name":"ReplayStopEvents","Description":"","Parameters":["Channel"]},{"Name":"ReplayStopRecording","Description":"","Parameters":null},{"Name":"ReplaySwapChannels","Description":"Swap A to B and vice versa, includes angles and playback status.","Parameters":null},{"Name":"ReplayToggleLastEventCamera1","Description":"","Parameters":null},{"Name":"ReplayToggleLastEventCamera2","Description":"","Parameters":null},{"Name":"ReplayToggleLastEventCamera3","Description":"","Parameters":null},{"Name":"ReplayToggleLastEventCamera4","Description":"","Parameters":null},{"Name":"ReplayToggleLastEventCamera5","Description":"","Parameters":null},{"Name":"ReplayToggleLastEventCamera6","Description":"","Parameters":null},{"Name":"ReplayToggleLastEventCamera7","Description":"","Parameters":null},{"Name":"ReplayToggleLastEventCamera8","Description":"","Parameters":null},{"Name":"ReplayToggleSelectedEventCamera1","Description":"","Parameters":null},{"Name":"ReplayToggleSelectedEventCamera2","Description":"","Parameters":null},{"Name":"ReplayToggleSelectedEventCamera3","Description":"","Parameters":null},{"Name":"ReplayToggleSelectedEventCamera4","Description":"","Parameters":null},{"Name":"ReplayToggleSelectedEventCamera5","Description":"","Parameters":null},{"Name":"ReplayToggleSelectedEventCamera6","Description":"","Parameters":null},{"Name":"ReplayToggleSelectedEventCamera7","Description":"","Parameters":null},{"Name":"ReplayToggleSelectedEventCamera8","Description":"","Parameters":null},{"Name":"ReplayUpdateSelectedInPoint","Description":"Update In point of Selected Event to current Position.","Parameters":["Channel"]},{"Name":"ReplayUpdateSelectedOutPoint","Description":"Update Mark Out point of Selected Event to current Position.","Parameters":["Channel"]},{"Name":"ReplayUpdateSelectedSpeed","Description":"Update Selected Event to use Current Speed.","Parameters":["Channel"]},{"Name":"ReplayUpdateSelectedSpeedDefault","Description":"Update Selected Event to use Default Speed.","Parameters":["Channel"]},{"Name":"ReplayUpdateSelectedSpeedFromValue","Description":"See SetRateSlowMotion      Value = Speed 0-1","Parameters":["Value","Channel"]},{"Name":"NDICommand","Description":"Send specified command to NDI source      Value = Command","Parameters":["Value","Input"]},{"Name":"NDISelectSourceByIndex","Description":"Value = Index 0-100","Parameters":["Value","Input"]},{"Name":"NDISelectSourceByName","Description":"Value = Name","Parameters":["Value","Input"]},{"Name":"NDIStartRecording","Description":"","Parameters":["Input"]},{"Name":"NDIStopRecording","Description":"","Parameters":["Input"]},{"Name":"PTZCreateVirtualInput","Description":"Creates a PTZ Virtual Input with the current Position","Parameters":["Input"]},{"Name":"PTZFocusAuto","Description":"","Parameters":["Input"]},{"Name":"PTZFocusFar","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZFocusManual","Description":"","Parameters":["Input"]},{"Name":"PTZFocusNear","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZFocusStop","Description":"","Parameters":["Input"]},{"Name":"PTZHome","Description":"","Parameters":["Input"]},{"Name":"PTZMoveDown","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZMoveDownLeft","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZMoveDownRight","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZMoveLeft","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZMoveRight","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZMoveStop","Description":"Stop all PTZ movement","Parameters":["Input"]},{"Name":"PTZMoveToVirtualInputPosition","Description":"Moves to the Position of the PTZ Virtual Input without selecting it into Preview","Parameters":["Input"]},{"Name":"PTZMoveToVirtualInputPositionByIndex","Description":"Moves to the Position of the PTZ Virtual Input associated with this Input. Index is first Input found starting from 0      Value = Index 0-100","Parameters":["Value","Input"]},{"Name":"PTZMoveUp","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZMoveUpLeft","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZMoveUpRight","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZUpdateVirtualInput","Description":"Updates selected PTZ Virtual Input with current Position","Parameters":["Input"]},{"Name":"PTZZoomIn","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZZoomOut","Description":"Value = Speed 0-1","Parameters":["Value","Input"]},{"Name":"PTZZoomStop","Description":"","Parameters":["Input"]},{"Name":"LastPreset","Description":"Load the last preset.","Parameters":null},{"Name":"OpenPreset","Description":"Load preset from the specified Filename.      Value = Filename","Parameters":["Value"]},{"Name":"SavePreset","Description":"Save preset to the specified Filename.      Value = Filename","Parameters":["Value"]},{"Name":"DataSourceAutoNextOff","Description":"Name of the Data Source, Table Name (optional) eg 'Excel/CSV,Sheet1'      Value = Name,Table","Parameters":["Value"]},{"Name":"DataSourceAutoNextOn","Description":"Name of the Data Source, Table Name (optional) eg 'Excel/CSV,Sheet1'      Value = Name,Table","Parameters":["Value"]},{"Name":"DataSourceAutoNextOnOff","Description":"Name of the Data Source, Table Name (optional) eg 'Excel/CSV,Sheet1'      Value = Name,Table","Parameters":["Value"]},{"Name":"DataSourceNextRow","Description":"Name of the Data Source and Table Name (optional) eg 'Excel/CSV,Sheet1'      Value = Name,Table","Parameters":["Value"]},{"Name":"DataSourcePause","Description":"Name of Data Source eg 'Excel/CSV'      Value = Name","Parameters":["Value"]},{"Name":"DataSourcePlay","Description":"Name of Data Source eg 'Excel/CSV'      Value = Name","Parameters":["Value"]},{"Name":"DataSourcePlayPause","Description":"Name of Data Source eg 'Excel/CSV'      Value = Name","Parameters":["Value"]},{"Name":"DataSourcePreviousRow","Description":"Name of the Data Source and Table Name (optional) eg 'Excel/CSV,Sheet1'      Value = Name,Table","Parameters":["Value"]},{"Name":"DataSourceSelectRow","Description":"Name of the Data Source, Table Name (optional) and Row Index starting from 0 eg 'Excel/CSV,Sheet1,5'      Value = Name,Table,Index","Parameters":["Value"]},{"Name":"BrowserBack","Description":"","Parameters":["Input"]},{"Name":"BrowserForward","Description":"","Parameters":["Input"]},{"Name":"BrowserKeyboardDisabled","Description":"","Parameters":["Input"]},{"Name":"BrowserKeyboardEnabled","Description":"","Parameters":["Input"]},{"Name":"BrowserMouseDisabled","Description":"","Parameters":["Input"]},{"Name":"BrowserMouseEnabled","Description":"","Parameters":["Input"]},{"Name":"BrowserNavigate","Description":"URL      Value = URL","Parameters":["Value","Input"]},{"Name":"BrowserReload","Description":"","Parameters":["Input"]}]
+[
+  {
+    "Name": "Cut",
+    "Description": "Cut",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "Fade",
+    "Description": "Fade",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "Zoom",
+    "Description": "Zoom",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "Wipe",
+    "Description": "Wipe",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "Slide",
+    "Description": "Slide",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "Fly",
+    "Description": "Fly",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "CrossZoom",
+    "Description": "CrossZoom",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "FlyRotate",
+    "Description": "FlyRotate",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "Cube",
+    "Description": "Cube",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "CubeZoom",
+    "Description": "CubeZoom",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "VerticalWipe",
+    "Description": "VerticalWipe",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "VerticalSlide",
+    "Description": "VerticalSlide",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "Merge",
+    "Description": "Merge",
+    "Parameters": [
+      "Input",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "WipeReverse",
+    "Description": "WipeReverse",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "SlideReverse",
+    "Description": "SlideReverse",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "VerticalWipeReverse",
+    "Description": "VerticalWipeReverse",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "VerticalSlideReverse",
+    "Description": "VerticalSlideReverse",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "BarnDoor",
+    "Description": "BarnDoor",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "RollerDoor",
+    "Description": "RollerDoor",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "AlphaFade",
+    "Description": "AlphaFade",
+    "Parameters": [
+      "Input",
+      "Mix",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "Name",
+    "Description": "Description",
+    "Parameters": [
+      "Parameters"
+    ]
+  },
+  {
+    "Name": "ActivatorRefresh",
+    "Description": "Refresh all activator device lights and controls",
+    "Parameters": null
+  },
+  {
+    "Name": "CallManagerShowHide",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "KeyPress",
+    "Description": "Value = Key",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SendKeys",
+    "Description": "Send keys to active window      Value = Keys",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetDynamicValue1",
+    "Description": "Set Dynamic Value to use when specifying Dynamic1 as a shortcut value.      Value = Value",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetDynamicValue2",
+    "Description": "Set Dynamic Value to use when specifying Dynamic2 as a shortcut value.      Value = Value",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetDynamicValue3",
+    "Description": "Set Dynamic Value to use when specifying Dynamic3 as a shortcut value.      Value = Value",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetDynamicValue4",
+    "Description": "Set Dynamic Value to use when specifying Dynamic4 as a shortcut value.      Value = Value",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "Undo",
+    "Description": "Undo closing Input.",
+    "Parameters": null
+  },
+  {
+    "Name": "Audio",
+    "Description": "Toggle Audio Mute On/Off",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioAuto",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioAutoOff",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioAutoOn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioBus",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioBusOff",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioBusOn",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioChannelMatrixApplyPreset",
+    "Description": "Apply preset to channel matrix      Value = Preset Name",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioMixerShowHide",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "AudioOff",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioOn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioPluginOff",
+    "Description": "Turn off Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioPluginOn",
+    "Description": "Turn on Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioPluginOnOff",
+    "Description": "Toggle on/off Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "AudioPluginShow",
+    "Description": "Show Audio Plugin Editor, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "BusAAudio",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "BusAAudioOff",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "BusAAudioOn",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "BusAAudioPluginOff",
+    "Description": "Turn off Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusAAudioPluginOn",
+    "Description": "Turn on Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusAAudioPluginOnOff",
+    "Description": "Toggle on/off Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusAAudioPluginShow",
+    "Description": "Show Audio Plugin Editor, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusBAudio",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "BusBAudioOff",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "BusBAudioOn",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "BusBAudioPluginOff",
+    "Description": "Turn off Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusBAudioPluginOn",
+    "Description": "Turn on Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusBAudioPluginOnOff",
+    "Description": "Toggle on/off Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusBAudioPluginShow",
+    "Description": "Show Audio Plugin Editor, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXAudio",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXAudioOff",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXAudioOn",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXAudioPluginOff",
+    "Description": "Turn off Audio Plugin, starting from 1      Value = Bus,PluginNumber",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXAudioPluginOn",
+    "Description": "Turn on Audio Plugin, starting from 1      Value = Bus,PluginNumber",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXAudioPluginOnOff",
+    "Description": "Toggle on/off Audio Plugin, starting from 1      Value = Bus,PluginNumber",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXAudioPluginShow",
+    "Description": "Show Audio Plugin Editor, starting from 1      Value = Bus,PluginNumber",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXSendToMaster",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXSendToMasterOff",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXSendToMasterOn",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXSolo",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXSoloOff",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BusXSoloOn",
+    "Description": "M,A,B,C,D,E,F,G      Value = Bus",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "MasterAudio",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "MasterAudioOff",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "MasterAudioOn",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "MasterAudioPluginOff",
+    "Description": "Turn off Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "MasterAudioPluginOn",
+    "Description": "Turn on Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "MasterAudioPluginOnOff",
+    "Description": "Toggle on/off Audio Plugin, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "MasterAudioPluginShow",
+    "Description": "Show Audio Plugin Editor, starting from 1      Value = Plugin Number",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBalance",
+    "Description": "Value = Balance -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetBusAVolume",
+    "Description": "Value = Volume 0-100",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusAVolumeFade",
+    "Description": "Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusBVolume",
+    "Description": "Value = Volume 0-100",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusBVolumeFade",
+    "Description": "Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusCVolume",
+    "Description": "Value = Volume 0-100",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusCVolumeFade",
+    "Description": "Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusDVolume",
+    "Description": "Value = Volume 0-100",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusDVolumeFade",
+    "Description": "Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusEVolume",
+    "Description": "Value = Volume 0-100",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusEVolumeFade",
+    "Description": "Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusFVolume",
+    "Description": "Value = Volume 0-100",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusFVolumeFade",
+    "Description": "Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusGVolume",
+    "Description": "Value = Volume 0-100",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetBusGVolumeFade",
+    "Description": "Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetGain",
+    "Description": "Value = Gain dB 0-24",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetGainChannel1",
+    "Description": "Value = Gain dB 0-24",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetGainChannel2",
+    "Description": "Value = Gain dB 0-24",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetHeadphonesVolume",
+    "Description": "Value = Volume 0-100",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetMasterVolume",
+    "Description": "Value = Volume 0-100",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetMasterVolumeFade",
+    "Description": "Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetVolume",
+    "Description": "Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeBusMixer",
+    "Description": "Set Volume of an Input's Bus Mixer (M,A,B,C,D,E,F,G)      Value = Bus,Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeBusMixerA",
+    "Description": "Set Volume of an Input's A Bus      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeBusMixerB",
+    "Description": "Set Volume of an Input's B Bus      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeBusMixerC",
+    "Description": "Set Volume of an Input's C Bus      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeBusMixerD",
+    "Description": "Set Volume of an Input's D Bus      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeBusMixerE",
+    "Description": "Set Volume of an Input's E Bus      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeBusMixerF",
+    "Description": "Set Volume of an Input's F Bus      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeBusMixerG",
+    "Description": "Set Volume of an Input's G Bus      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeBusMixerM",
+    "Description": "Set Volume of an Input's Master Bus      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannel1",
+    "Description": "When using SeparateMono on an Audio Input, this can be used to set channel volumes independently.      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannel2",
+    "Description": "When using SeparateMono on an Audio Input, this can be used to set channel volumes independently.      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer",
+    "Description": "Set Volume of an Input's sub channel (1 to 16)      Value = Channel,Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer1",
+    "Description": "Set Volume of an Input's sub channel 1      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer10",
+    "Description": "Set Volume of an Input's sub channel 10      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer11",
+    "Description": "Set Volume of an Input's sub channel 11      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer12",
+    "Description": "Set Volume of an Input's sub channel 12      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer13",
+    "Description": "Set Volume of an Input's sub channel 13      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer14",
+    "Description": "Set Volume of an Input's sub channel 14      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer15",
+    "Description": "Set Volume of an Input's sub channel 15      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer16",
+    "Description": "Set Volume of an Input's sub channel 16      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer2",
+    "Description": "Set Volume of an Input's sub channel 2      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer3",
+    "Description": "Set Volume of an Input's sub channel 3      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer4",
+    "Description": "Set Volume of an Input's sub channel 4      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer5",
+    "Description": "Set Volume of an Input's sub channel 5      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer6",
+    "Description": "Set Volume of an Input's sub channel 6      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer7",
+    "Description": "Set Volume of an Input's sub channel 7      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer8",
+    "Description": "Set Volume of an Input's sub channel 8      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeChannelMixer9",
+    "Description": "Set Volume of an Input's sub channel 9      Value = Volume 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetVolumeFade",
+    "Description": "Set volume gradually over x milliseconds.      Value = Volume 0-100,Milliseconds",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "Solo",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SoloAllOff",
+    "Description": "Turn off Solo for all Inputs and Busses",
+    "Parameters": null
+  },
+  {
+    "Name": "SoloOff",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SoloOn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SoloPFL",
+    "Description": "Toggle between AFL or PFL mode for Solo",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SoloPFLOff",
+    "Description": "Turn off PFL mode for Solo",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SoloPFLOn",
+    "Description": "Turn on PFL mode for Solo",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "CutDirect",
+    "Description": "Cuts the input directly to Output without changing Preview",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "FadeToBlack",
+    "Description": "Toggle FTB On/Off",
+    "Parameters": null
+  },
+  {
+    "Name": "QuickPlay",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetFader",
+    "Description": "Set Master Fader T-Bar, 255 will cut to Preview      Value = Fader 0-255",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetStingerGTInput1",
+    "Description": "Assign GT Input as animation source for Stinger 1",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetStingerGTInput2",
+    "Description": "Assign GT Input as animation source for Stinger 2",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetStingerGTInput3",
+    "Description": "Assign GT Input as animation source for Stinger 3",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetStingerGTInput4",
+    "Description": "Assign GT Input as animation source for Stinger 4",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetStingerGTInput5",
+    "Description": "Assign GT Input as animation source for Stinger 5",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetStingerGTInput6",
+    "Description": "Assign GT Input as animation source for Stinger 6",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetStingerGTInput7",
+    "Description": "Assign GT Input as animation source for Stinger 7",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetStingerGTInput8",
+    "Description": "Assign GT Input as animation source for Stinger 8",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetTransitionDuration1",
+    "Description": "Change Transition Duration for Button 1      Value = Duration MS",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetTransitionDuration2",
+    "Description": "Change Transition Duration for Button 2      Value = Duration MS",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetTransitionDuration3",
+    "Description": "Change Transition Duration for Button 3      Value = Duration MS",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetTransitionDuration4",
+    "Description": "Change Transition Duration for Button 4      Value = Duration MS",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetTransitionEffect1",
+    "Description": "Change Transition for Button 1      Value = Transition",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetTransitionEffect2",
+    "Description": "Change Transition for Button 2      Value = Transition",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetTransitionEffect3",
+    "Description": "Change Transition for Button 3      Value = Transition",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetTransitionEffect4",
+    "Description": "Change Transition for Button 4      Value = Transition",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "Stinger1",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "Stinger2",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "Stinger3",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "Stinger4",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "Stinger5",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "Stinger6",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "Stinger7",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "Stinger8",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "Transition1",
+    "Description": "Clicks one of the four Transition buttons in the main vMix window.",
+    "Parameters": null
+  },
+  {
+    "Name": "Transition2",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "Transition3",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "Transition4",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "Fullscreen",
+    "Description": "Toggles Fullscreen On or Off",
+    "Parameters": null
+  },
+  {
+    "Name": "FullscreenOff",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "FullscreenOn",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "SetOutput2",
+    "Description": "Change what is displayed on Output 2.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input",
+    "Parameters": [
+      "Value",
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "SetOutput3",
+    "Description": "Change what is displayed on Output 3.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input",
+    "Parameters": [
+      "Value",
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "SetOutput4",
+    "Description": "Change what is displayed on Output 4.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input",
+    "Parameters": [
+      "Value",
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "SetOutputExternal2",
+    "Description": "Change what is displayed on the External2 output.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input",
+    "Parameters": [
+      "Value",
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "SetOutputFullscreen",
+    "Description": "Change what is displayed on the Fullscreen output.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input",
+    "Parameters": [
+      "Value",
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "SetOutputFullscreen2",
+    "Description": "Change what is displayed on the Fullscreen2 output.      Output,Preview,MultiView,Replay,Mix,Input      Value = Output, Preview, MultiView, Replay, Mix, Input",
+    "Parameters": [
+      "Value",
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "Snapshot",
+    "Description": "Create a snapshot image of the current Output. Optional Value specifies save Filename, otherwise a save file window will appear. Filename can specify date, for example mysnapshot {0:dd MMM yyyy}.jpg      Value = Value",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SnapshotInput",
+    "Description": "Create a snapshot image of the selected Input. Optional Value specifies save Filename, otherwise a save file window will appear. Filename can specify date, for example mysnapshot {0:dd MMM yyyy}.jpg      Value = Value",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "StartExternal",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "StartMultiCorder",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "StartRecording",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "StartSRTOutput",
+    "Description": "Optional output number starting from 0. Leave blank to control Output 1 only.      Value = Output",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "StartStopExternal",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "StartStopMultiCorder",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "StartStopRecording",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "StartStopSRTOutput",
+    "Description": "Optional output number starting from 0. Leave blank to control Output 1 only.      Value = Output",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "StartStopStreaming",
+    "Description": "Optional stream number starting from 0. Leave blank to control all streams.      Value = Stream",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "StartStreaming",
+    "Description": "Optional stream number starting from 0. Leave blank to control all streams.      Value = Stream",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "StopExternal",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "StopMultiCorder",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "StopRecording",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "StopSRTOutput",
+    "Description": "Optional output number starting from 0. Leave blank to control Output 1 only.      Value = Output",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "StopStreaming",
+    "Description": "Optional stream number starting from 0. Leave blank to control all streams.      Value = Stream",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "StreamingSetKey",
+    "Description": "Set Key on Custom RTMP Stream. Optional stream number starting from 0 at start followed by comma, e.g 0,mystreamkey      Value = Stream",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "StreamingSetPassword",
+    "Description": "Set Password on Custom RTMP Stream. Optional stream number starting from 0 at start followed by comma, e.g 0,password      Value = Stream",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "StreamingSetURL",
+    "Description": "Set URL on Custom RTMP Stream. Optional stream number starting from 0 at start followed by comma, e.g 0,rtmp://myurl/      Value = Stream",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "StreamingSetUsername",
+    "Description": "Set Username on Custom RTMP Stream. Optional stream number starting from 0 at start followed by comma, e.g 0,username      Value = Stream",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "WriteDurationToRecordingLog",
+    "Description": "Write current recording duration to log file with optional tag text Value.      Value = Tag Text",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "AdjustCountdown",
+    "Description": "Seconds to add or subtract from current Countdown time      Value = Seconds",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "ChangeCountdown",
+    "Description": "Change countdown time according to Value as hh:mm:ss (00:00:00)      Value = Time 00:00:00",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "NextTitlePreset",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PauseCountdown",
+    "Description": "Pause or Resume Countdown or if complete, Start from beginning.",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PauseRender",
+    "Description": "Freeze Title Input while making multiple updates",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PreviousTitlePreset",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "ResumeRender",
+    "Description": "Resume Title Input rendering after making multiple updates",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SelectTitlePreset",
+    "Description": "Value = Preset Index",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetColor",
+    "Description": "Change Color in Title using HTML #xxxxxxxx format.      SelectedIndex or SelectedName can be used to select object.      Value = Color",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCountdown",
+    "Description": "Set countdown duration according to Value as hh:mm:ss (00:00:00)      Value = Duration 00:00:00",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetImage",
+    "Description": "Change Image in Title according to Filename or empty to clear.      SelectedIndex or SelectedName can be used to select image.      Value = Filename",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetImageVisible",
+    "Description": "Toggle Image Visibility in Title      SelectedIndex or SelectedName can be used to select image.",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetImageVisibleOff",
+    "Description": "Hide Image in Title      SelectedIndex or SelectedName can be used to select image.",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetImageVisibleOn",
+    "Description": "Show Image in Title      SelectedIndex or SelectedName can be used to select image.",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetText",
+    "Description": "Change Text in Title according to Value parameter.      SelectedIndex or SelectedName can be used to select Text Field      Value = Text",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetTextColour",
+    "Description": "Change Colour of Text in Title in HTML format (#xxxxxx)      Value = Colour",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetTextVisible",
+    "Description": "Toggle Text Visibility in Title      SelectedIndex or SelectedName can be used to select text field.",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetTextVisibleOff",
+    "Description": "Hide Text in Title      SelectedIndex or SelectedName can be used to select text field.",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetTextVisibleOn",
+    "Description": "Show Text in Title      SelectedIndex or SelectedName can be used to select text field.",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetTickerSpeed",
+    "Description": "Change Ticker Speed.      SelectedIndex or SelectedName can be used to select ticker field.      Value = Speed 0-1000",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "StartCountdown",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "StopCountdown",
+    "Description": "Stop and Reset Countdown",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SuspendCountdown",
+    "Description": "Pause Countdown Only",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "TitleBeginAnimation",
+    "Description": "Value = Animation",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "ActiveInput",
+    "Description": "Send to Output the selected Input",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "AddInput",
+    "Description": "Create a new Input based on information provided in Value.      Video|c:\\path\\to\\video.avi      Image|c:\\path\\to\\image.jpg      Photos|c:\\path\\to\\folder      Title|c:\\path\\to\\title.gtzip      VideoList|c:\\path\\to\\playlist.m3u      Colour|HTMLColor      AudioFile|c:\\path\\to\\audio.wav      Flash|c:\\path\\to\\flash.swf      PowerPoint|c:\\path\\to\\powerpoint.pptx      Value = Type|Filename",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "AutoPauseOff",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AutoPauseOn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AutoPlayFirst",
+    "Description": "Toggle automatically playing first item in a List with Transition",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AutoPlayFirstOff",
+    "Description": "Turn Off automatically playing first item in a List with Transition",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AutoPlayFirstOn",
+    "Description": "Turn On automatically playing first item in a List with Transition",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AutoPlayNext",
+    "Description": "Toggle automatically playing next item in a List",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AutoPlayNextOff",
+    "Description": "Turn Off automatically playing next item in a List",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AutoPlayNextOn",
+    "Description": "Turn On automatically playing next item in a List",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AutoPlayOff",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AutoPlayOn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AutoRestartOff",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "AutoRestartOn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "ColourCorrectionAuto",
+    "Description": "Basic Auto Colour Correction.",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "ColourCorrectionReset",
+    "Description": "Reset Colour Correction to Default Values.",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "CreateVirtualInput",
+    "Description": "Create a new Virtual Input from the specified Input.",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "DeinterlaceOff",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "DeinterlaceOn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect1",
+    "Description": "Toggle Effect 1 On/Off",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect1Off",
+    "Description": "Turn Effect 1 Off",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect1On",
+    "Description": "Turn Effect 1 On",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect2",
+    "Description": "Toggle Effect 2 On/Off",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect2Off",
+    "Description": "Turn Effect 2 Off",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect2On",
+    "Description": "Turn Effect 2 On",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect3",
+    "Description": "Toggle Effect 3 On/Off",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect3Off",
+    "Description": "Turn Effect 3 Off",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect3On",
+    "Description": "Turn Effect 3 On",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect4",
+    "Description": "Toggle Effect 4 On/Off",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect4Off",
+    "Description": "Turn Effect 4 Off",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Effect4On",
+    "Description": "Turn Effect 4 On",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "GO",
+    "Description": "Trigger GO action on Input",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "InputPreviewHide",
+    "Description": "Hides large preview of input",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "InputPreviewShow",
+    "Description": "Shows large preview of input",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "InputPreviewShowHide",
+    "Description": "Toggles large preview of input",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "LayerOff",
+    "Description": "Turn Off Layer For Input At Index (starting from 1)      Value = Index",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "LayerOn",
+    "Description": "Turn On Layer For Input At Index (starting from 1)      Value = Index",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "LayerOnOff",
+    "Description": "Toggle On/Off Layer For Input At Index (starting from 1)      Value = Index",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "ListAdd",
+    "Description": "Add Filename to List      Value = Filename",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "ListExport",
+    "Description": "Export List as M3U to Filename      Value = Filename",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "ListPlayOut",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "ListRemove",
+    "Description": "Remove from List by Index starting from 1      Value = Index",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "ListRemoveAll",
+    "Description": "Remove all items from List",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "ListShowHide",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "ListShuffle",
+    "Description": "Shuffle (randomize) List",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "LivePlayPause",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Loop",
+    "Description": "Toggle Loop on Input",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "LoopOff",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "LoopOn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "MarkIn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "MarkOut",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "MarkReset",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "MarkResetIn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "MarkResetOut",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "MirrorOff",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "MirrorOn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "MoveInput",
+    "Description": "Value = Number",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "MoveLayer",
+    "Description": "Move Layer in Input according to Value parameter.      Example: 1,2 moves Layer1 to Layer2      Value = FromIndex,ToIndex",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "NextItem",
+    "Description": "Move to next item in List",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "NextPicture",
+    "Description": "Move to Next Picture for Photo and PowerPoint Inputs",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Pause",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Play",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PlayPause",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PreviewInput",
+    "Description": "Send to Preview the selected Input",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "PreviewInputNext",
+    "Description": "Send to Preview the next Input",
+    "Parameters": null
+  },
+  {
+    "Name": "PreviewInputPrevious",
+    "Description": "Send to Preview the previous Input",
+    "Parameters": null
+  },
+  {
+    "Name": "PreviousItem",
+    "Description": "Move to previous item in List",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PreviousPicture",
+    "Description": "Move to Previous Picture for Photo and PowerPoint Inputs",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "RemoveInput",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "ResetInput",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "Restart",
+    "Description": "Restart selected Input",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SaveVideoDelay",
+    "Description": "Save video clip from Video Delay according to Duration in milliseconds",
+    "Parameters": [
+      "Input",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "SelectCategory",
+    "Description": "Change to Category according to Value (All,Red,Green,Orange,Purple,Aqua,Blue,Custom1-16,Search)      Value = Category",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SelectIndex",
+    "Description": "Photos,List: Selects item in List according to Value starting from number 1      Virtual Set: Zooms to selected preset using the current speed settings      Title: Starts Page animation according to Value starting from number 1      Value = Index",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetAlpha",
+    "Description": "Set Input transparency according to Value. 0 is transparent, 255 is opaque      Value = Alpha 0-255",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCGainB",
+    "Description": "Change Gain B level of Input.      1=Original      Value = Value 0-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCGainG",
+    "Description": "Change Gain G level of Input.      1=Original      Value = Value 0-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCGainR",
+    "Description": "Change Gain R level of Input.      1=Original      Value = Value 0-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCGainRGB",
+    "Description": "Change Gain RGB level of Input.      1=Original      Value = Value 0-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCGainY",
+    "Description": "Change Gain Y level of Input.      1=Original      Value = Value 0-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCGammaB",
+    "Description": "Change Gamma B level of Input.      0=Original      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCGammaG",
+    "Description": "Change Gamma G level of Input.      0=Original      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCGammaR",
+    "Description": "Change Gamma R level of Input.      0=Original      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCGammaRGB",
+    "Description": "Change Gamma RGB level of Input.      0=Original      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCGammaY",
+    "Description": "Change Gamma Y level of Input.      0=Original      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCHue",
+    "Description": "Change Hue level of Input.      0=Original      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCLiftB",
+    "Description": "Change Lift B level of Input.      0=Original      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCLiftG",
+    "Description": "Change Lift G level of Input.      0=Original      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCLiftR",
+    "Description": "Change Lift R level of Input.      0=Original      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCLiftRGB",
+    "Description": "Change Lift RGB level of Input.      0=Original      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCLiftY",
+    "Description": "Change Lift Y level of Input.      0=Original      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCCSaturation",
+    "Description": "Change Saturation level of Input.      0=Original, -1=Greyscale      Value = Value -1-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCrop",
+    "Description": "Change current Crop value of Input.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCropX1",
+    "Description": "Change current Crop X1 value of Input.      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCropX2",
+    "Description": "Change current Crop X2 value of Input.      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCropY1",
+    "Description": "Change current Crop Y1 value of Input.      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetCropY2",
+    "Description": "Change current Crop Y2 value of Input.      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetDynamicInput1",
+    "Description": "Set Dynamic Input from Input Name or Number      Value = Input",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetDynamicInput2",
+    "Description": "Set Dynamic Input from Input Name or Number      Value = Input",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetDynamicInput3",
+    "Description": "Set Dynamic Input from Input Name or Number      Value = Input",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetDynamicInput4",
+    "Description": "Set Dynamic Input from Input Name or Number      Value = Input",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SetEffect1Strength",
+    "Description": "Set Input 1 Effect Strength      Value = Value 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetEffect2Strength",
+    "Description": "Set Input 2 Effect Strength      Value = Value 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetEffect3Strength",
+    "Description": "Set Input 3 Effect Strength      Value = Value 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetEffect4Strength",
+    "Description": "Set Input 4 Effect Strength      Value = Value 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetFrameDelay",
+    "Description": "Set the delay in frames      Value = Frames",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetInputName",
+    "Description": "Set the Display Name of the Input      Value = Name",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer",
+    "Description": "Change Layer in Input according to Value parameter.      Example: 1,2 changes Layer1 to Input2      Value = Index,Input",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10Crop",
+    "Description": "Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10CropX1",
+    "Description": "Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10CropX2",
+    "Description": "Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10CropY1",
+    "Description": "Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10CropY2",
+    "Description": "Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10Height",
+    "Description": "Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10PanX",
+    "Description": "Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10PanY",
+    "Description": "Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10Rectangle",
+    "Description": "Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10Width",
+    "Description": "Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10X",
+    "Description": "Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10Y",
+    "Description": "Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer10Zoom",
+    "Description": "Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1Crop",
+    "Description": "Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1CropX1",
+    "Description": "Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1CropX2",
+    "Description": "Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1CropY1",
+    "Description": "Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1CropY2",
+    "Description": "Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1Height",
+    "Description": "Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1PanX",
+    "Description": "Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1PanY",
+    "Description": "Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1Rectangle",
+    "Description": "Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1Width",
+    "Description": "Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1X",
+    "Description": "Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1Y",
+    "Description": "Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer1Zoom",
+    "Description": "Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2Crop",
+    "Description": "Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2CropX1",
+    "Description": "Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2CropX2",
+    "Description": "Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2CropY1",
+    "Description": "Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2CropY2",
+    "Description": "Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2Height",
+    "Description": "Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2PanX",
+    "Description": "Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2PanY",
+    "Description": "Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2Rectangle",
+    "Description": "Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2Width",
+    "Description": "Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2X",
+    "Description": "Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2Y",
+    "Description": "Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer2Zoom",
+    "Description": "Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3Crop",
+    "Description": "Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3CropX1",
+    "Description": "Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3CropX2",
+    "Description": "Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3CropY1",
+    "Description": "Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3CropY2",
+    "Description": "Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3Height",
+    "Description": "Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3PanX",
+    "Description": "Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3PanY",
+    "Description": "Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3Rectangle",
+    "Description": "Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3Width",
+    "Description": "Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3X",
+    "Description": "Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3Y",
+    "Description": "Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer3Zoom",
+    "Description": "Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4Crop",
+    "Description": "Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4CropX1",
+    "Description": "Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4CropX2",
+    "Description": "Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4CropY1",
+    "Description": "Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4CropY2",
+    "Description": "Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4Height",
+    "Description": "Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4PanX",
+    "Description": "Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4PanY",
+    "Description": "Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4Rectangle",
+    "Description": "Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4Width",
+    "Description": "Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4X",
+    "Description": "Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4Y",
+    "Description": "Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer4Zoom",
+    "Description": "Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5Crop",
+    "Description": "Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5CropX1",
+    "Description": "Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5CropX2",
+    "Description": "Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5CropY1",
+    "Description": "Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5CropY2",
+    "Description": "Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5Height",
+    "Description": "Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5PanX",
+    "Description": "Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5PanY",
+    "Description": "Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5Rectangle",
+    "Description": "Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5Width",
+    "Description": "Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5X",
+    "Description": "Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5Y",
+    "Description": "Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer5Zoom",
+    "Description": "Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6Crop",
+    "Description": "Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6CropX1",
+    "Description": "Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6CropX2",
+    "Description": "Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6CropY1",
+    "Description": "Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6CropY2",
+    "Description": "Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6Height",
+    "Description": "Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6PanX",
+    "Description": "Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6PanY",
+    "Description": "Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6Rectangle",
+    "Description": "Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6Width",
+    "Description": "Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6X",
+    "Description": "Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6Y",
+    "Description": "Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer6Zoom",
+    "Description": "Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7Crop",
+    "Description": "Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7CropX1",
+    "Description": "Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7CropX2",
+    "Description": "Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7CropY1",
+    "Description": "Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7CropY2",
+    "Description": "Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7Height",
+    "Description": "Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7PanX",
+    "Description": "Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7PanY",
+    "Description": "Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7Rectangle",
+    "Description": "Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7Width",
+    "Description": "Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7X",
+    "Description": "Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7Y",
+    "Description": "Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer7Zoom",
+    "Description": "Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8Crop",
+    "Description": "Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8CropX1",
+    "Description": "Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8CropX2",
+    "Description": "Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8CropY1",
+    "Description": "Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8CropY2",
+    "Description": "Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8Height",
+    "Description": "Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8PanX",
+    "Description": "Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8PanY",
+    "Description": "Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8Rectangle",
+    "Description": "Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8Width",
+    "Description": "Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8X",
+    "Description": "Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8Y",
+    "Description": "Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer8Zoom",
+    "Description": "Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9Crop",
+    "Description": "Change current Crop value of Input Layer.      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9CropX1",
+    "Description": "Change current Crop X1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9CropX2",
+    "Description": "Change current Crop X2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9CropY1",
+    "Description": "Change current Crop Y1 value of Input Layer.      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9CropY2",
+    "Description": "Change current Crop Y2 value of Input Layer.      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9Height",
+    "Description": "Change current Height value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9PanX",
+    "Description": "Change current PanX value of Input Layer.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9PanY",
+    "Description": "Change current PanY value of Input Layer.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9Rectangle",
+    "Description": "Change current Rectangle values of Input Layer in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9Width",
+    "Description": "Change current Width value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9X",
+    "Description": "Change current X value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9Y",
+    "Description": "Change current Y value of Input Layer.      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayer9Zoom",
+    "Description": "Change current Zoom level of Input Layer.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerAnimated",
+    "Description": "Change Layer Index to Input. Animate if input exists in another layer.      Example: 1,2,1000 changes Layer1 to Input2.      Value = Index,Input,DurationMilliseconds",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicCrop",
+    "Description": "Change current Crop value of Input Layer from DynamicValue1 (1-10).      X1,Y1,X2,Y2 (values between 0 and 1)      Value = X1,Y1,X2,Y2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicCropX1",
+    "Description": "Change current Crop X1 value of Input Layer from DynamicValue1 (1-10).      0=No Crop, 1=Full Crop      Value = X1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicCropX2",
+    "Description": "Change current Crop X2 value of Input Layer from DynamicValue1 (1-10).      1=No Crop, 0=Full Crop      Value = X2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicCropY1",
+    "Description": "Change current Crop Y1 value of Input Layer from DynamicValue1 (1-10).      0=No Crop, 1=Full Crop      Value = Y1 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicCropY2",
+    "Description": "Change current Crop Y2 value of Input Layer from DynamicValue1 (1-10).      1=No Crop, 0=Full Crop      Value = Y2 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicHeight",
+    "Description": "Change current Height value of Input Layer from DynamicValue1 (1-10).      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicPanX",
+    "Description": "Change current PanX value of Input Layer from DynamicValue1 (1-10).      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicPanY",
+    "Description": "Change current PanY value of Input Layer from DynamicValue1 (1-10).      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicRectangle",
+    "Description": "Change current Rectangle values of Input Layer from DynamicValue1 (1-10) in pixels.      X,Y,Width,Height      Value = X,Y,Width,Height",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicWidth",
+    "Description": "Change current Width value of Input Layer from DynamicValue1 (1-10).      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicX",
+    "Description": "Change current X value of Input Layer from DynamicValue1 (1-10).      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicY",
+    "Description": "Change current Y value of Input Layer from DynamicValue1 (1-10).      In pixels based on preset resolution      Value = Pixels -4096-4096",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetLayerDynamicZoom",
+    "Description": "Change current Zoom level of Input Layer from DynamicValue1 (1-10).      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetPanX",
+    "Description": "Change current PanX value of Input.      0=centered, -2=100% to left, 2=100% to right      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetPanY",
+    "Description": "Change current PanY value of Input.      0=centered, -2=100% to bottom, 2=100% to top      Value = Pan -2-2",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetPictureEffect",
+    "Description": "Set transition effect for Photos and PowerPoint Inputs (Fade, Zoom, etc)      Value = Transition",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetPictureEffectDuration",
+    "Description": "Set duration of transition effect in Milliseconds      Value = Duration MS",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetPictureTransition",
+    "Description": "Set transition time between Photos and PowerPoint slides in Seconds      Value = Seconds",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetPosition",
+    "Description": "Set Position of selected Input according to Value in Milliseconds      Value = Milliseconds",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetRate",
+    "Description": "Set Playback speed/rate for Videos and Video Delays      0.5=50%,1=100%,2=200% etc      Value = Speed 0.1-4",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetRateSlowMotion",
+    "Description": "Set Slow Motion speed for Instant Replay      0.5=50%,1=100% etc      Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetZoom",
+    "Description": "Change current Zoom level of Input.      1=100%, 0.5=50%, 2=200%      Value = Zoom 0-5",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "SharpenOff",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SharpenOn",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SwapLayerAnimated",
+    "Description": "Animate swapping the Layers in Input according to Value parameter.      Example: 1,2,1000 swaps Layer1 and Layer2 over 1000 milliseconds.      Value = FromIndex,ToIndex,DurationMilliseconds",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "VideoCallAudioSource",
+    "Description": "Master,Headphones,BusA,BusB,BusC,BusD,BusE,BusF,BusG      Value = Source",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "VideoCallConnect",
+    "Description": "Value = Name,Password",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "VideoCallReconnect",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "VideoCallVideoSource",
+    "Description": "Output1,Output2,Output3,Output4      Value = Source",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "VideoDelayStartRecording",
+    "Description": "Start Video Delay Recording",
+    "Parameters": [
+      "Input",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "VideoDelayStartStopRecording",
+    "Description": "Toggle Video Delay Recording",
+    "Parameters": [
+      "Input",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "VideoDelayStopRecording",
+    "Description": "Stop Video Delay Recording",
+    "Parameters": [
+      "Input",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "WaitForCompletion",
+    "Description": "Wait for a Video Input to reach the end of playback.",
+    "Parameters": [
+      "Input",
+      "Duration"
+    ]
+  },
+  {
+    "Name": "ZoomJoinMeeting",
+    "Description": "Value = MeetingID,Password",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "ZoomMuteSelf",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "ZoomSelectParticipantByName",
+    "Description": "Value = Name",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "ZoomUnMuteSelf",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "MoveMultiViewOverlay",
+    "Description": "Move Overlay in Input MultiView according to Value parameter.      Example: 1,2 moves Overlay1 to Overlay2      Value = FromIndex,ToIndex",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "MultiViewOverlay",
+    "Description": "Toggle On/Off MultiView Overlay For Input At Index (starting from 1)      Value = Index",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "MultiViewOverlayOff",
+    "Description": "Turn Off MultiView Overlay For Input At Index (starting from 1)      Value = Index",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "MultiViewOverlayOn",
+    "Description": "Turn On MultiView Overlay For Input At Index (starting from 1)      Value = Index",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "OverlayInput1",
+    "Description": "Toggle Overlay1 On/Off with selected Input using configured Transition",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput1In",
+    "Description": "Transition In to Overlay1 with selected Input",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput1Last",
+    "Description": "Toggle Overlay1 On/Off with last used Input on this channel",
+    "Parameters": [
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput1Off",
+    "Description": "Immediately switch Overlay1 Off (Cut)",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput1Out",
+    "Description": "Transition Out Overlay1",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput1Zoom",
+    "Description": "Zooms PIP Overlay to fill Fullscreen and vice versa",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput2",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput2In",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput2Last",
+    "Description": "Toggle Overlay2 On/Off with last used Input on this channel",
+    "Parameters": [
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput2Off",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput2Out",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput2Zoom",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput3",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput3In",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput3Last",
+    "Description": "Toggle Overlay3 On/Off with last used Input on this channel",
+    "Parameters": [
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput3Off",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput3Out",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput3Zoom",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput4",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput4In",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput4Last",
+    "Description": "Toggle Overlay4 On/Off with last used Input on this channel",
+    "Parameters": [
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput4Off",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput4Out",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput4Zoom",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput5",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput5In",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput5Last",
+    "Description": "Toggle Overlay5 On/Off with last used Input on this channel",
+    "Parameters": [
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput5Off",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput5Out",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput5Zoom",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput6",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput6In",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput6Last",
+    "Description": "Toggle Overlay6 On/Off with last used Input on this channel",
+    "Parameters": [
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput6Off",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput6Out",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput6Zoom",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput7",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput7In",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput7Last",
+    "Description": "Toggle Overlay7 On/Off with last used Input on this channel",
+    "Parameters": [
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput7Off",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput7Out",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput7Zoom",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput8",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput8In",
+    "Description": "",
+    "Parameters": [
+      "Input",
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput8Last",
+    "Description": "Toggle Overlay8 On/Off with last used Input on this channel",
+    "Parameters": [
+      "Mix"
+    ]
+  },
+  {
+    "Name": "OverlayInput8Off",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput8Out",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInput8Zoom",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "OverlayInputAllOff",
+    "Description": "Immediately switch all Overlays Off",
+    "Parameters": null
+  },
+  {
+    "Name": "PreviewOverlayInput1",
+    "Description": "Preview Overlay1 using the selected Input",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PreviewOverlayInput2",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PreviewOverlayInput3",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PreviewOverlayInput4",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PreviewOverlayInput5",
+    "Description": "Preview Overlay5 using the selected Input",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PreviewOverlayInput6",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PreviewOverlayInput7",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PreviewOverlayInput8",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "SetMultiViewOverlay",
+    "Description": "Change Layer in Input MultiView according to Value parameter.      Example: 1,2 changes Layer 1 to Input2      Value = Index,Input",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "NextPlayListEntry",
+    "Description": "Move to Next Item in a running PlayList",
+    "Parameters": null
+  },
+  {
+    "Name": "PreviousPlayListEntry",
+    "Description": "Move to Previous Item in a running PlayList",
+    "Parameters": null
+  },
+  {
+    "Name": "SelectPlayList",
+    "Description": "Open PlayList with Name matching Value      Value = PlayList",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "StartPlayList",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "StopPlayList",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ScriptStart",
+    "Description": "Value = Script Name",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ScriptStartDynamic",
+    "Description": "Start a dynamic script using code specified as the Value.      Value = Code",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ScriptStop",
+    "Description": "Value = Script Name",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ScriptStopAll",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ScriptStopDynamic",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayACamera1",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayACamera2",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayACamera3",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayACamera4",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayACamera5",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayACamera6",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayACamera7",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayACamera8",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayAppendLastEventText",
+    "Description": "Value = Text",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayAppendLastEventTextCamera",
+    "Description": "Adds the text to the specified angle (1-4), example: 3,angle3text      Value = Camera,Text",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayAppendSelectedEventText",
+    "Description": "Value = Text",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayAppendSelectedEventTextCamera",
+    "Description": "Adds the text to the specified angle (1-4), example: 3,angle3text      Value = Camera,Text",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayBCamera1",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayBCamera2",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayBCamera3",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayBCamera4",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayBCamera5",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayBCamera6",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayBCamera7",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayBCamera8",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCamera1",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCamera2",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCamera3",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCamera4",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCamera5",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCamera6",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCamera7",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCamera8",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCCamera1",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCCamera2",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCCamera3",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCCamera4",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCCamera5",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCCamera6",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCCamera7",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayCCamera8",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayChangeDirection",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayChangeSpeed",
+    "Description": "Value = Speed",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayCopyLastEvent",
+    "Description": "Value = Event List 0-19",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayCopySelectedEvent",
+    "Description": "Value = Event List 0-19",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayDCamera1",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayDCamera2",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayDCamera3",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayDCamera4",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayDCamera5",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayDCamera6",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayDCamera7",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayDCamera8",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayDeleteLastEvent",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayDeleteSelectedEvent",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayDuplicateLastEvent",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayDuplicateSelectedEvent",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayExportLastEvent",
+    "Description": "Value = Folder",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayFastBackward",
+    "Description": "1-30x      Value = Speed",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayFastForward",
+    "Description": "1-30x      Value = Speed",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayJumpFrames",
+    "Description": "Value = Frames",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayJumpFramesFastOff",
+    "Description": "ReplayJumpFrames jumps 1 frame for each value instead of 1 second.",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayJumpFramesFastOn",
+    "Description": "ReplayJumpFrames jumps 1 second for each value instead of 1 frame.",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayJumpToNow",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayJumpToSelectedInPoint",
+    "Description": "Set Position to In point of Selected Event.",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayJumpToSelectedOutPoint",
+    "Description": "Set Position to Out point of Selected Event.",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayLastEventCameraOff",
+    "Description": "Turns off the specified camera angle (1-8)      Value = Camera",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayLastEventCameraOn",
+    "Description": "Turns on the specified camera angle (1-8)      Value = Camera",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayLastEventSingleCameraOn",
+    "Description": "Turns on only the specified camera angle (1-8)      Value = Camera",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayLive",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayLiveToggle",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayMarkCancel",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayMarkIn",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayMarkInLive",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayMarkInOut",
+    "Description": "Number of previous seconds to use when creating a new event.      Value = Seconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayMarkInOutLive",
+    "Description": "Number of previous seconds to use when creating a new event.      Value = Seconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayMarkInOutLiveFuture",
+    "Description": "Number of seconds into the future to use when creating a new event.      Value = Seconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayMarkInOutRecorded",
+    "Description": "Number of previous seconds to use when creating a new event.      Value = Seconds",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayMarkInRecorded",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayMarkInRecordedNow",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayMarkOut",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayMoveLastEvent",
+    "Description": "Value = Event List 0-19",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayMoveSelectedEvent",
+    "Description": "Value = Event List 0-19",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplayMoveSelectedEventDown",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayMoveSelectedEventUp",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayMoveSelectedInPoint",
+    "Description": "Value = Frames",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayMoveSelectedOutPoint",
+    "Description": "Value = Frames",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPause",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlay",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayAllEvents",
+    "Description": "Play all Events in active list",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayAllEventsToOutput",
+    "Description": "Play all Events in active list",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayBackward",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayEvent",
+    "Description": "Value = Event Number where 0 is bottom of list 0-1000",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayEventsByID",
+    "Description": "Value = List of IDs",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayEventsByIDToOutput",
+    "Description": "Value = List of IDs",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayEventToOutput",
+    "Description": "Value = Event Number where 0 is bottom of list 0-1000",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayForward",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayLastEvent",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayLastEventToOutput",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayNext",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayPause",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlayPrevious",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlaySelectedEvent",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayPlaySelectedEventToOutput",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayQuadModeOff",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayQuadModeOn",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayRecorded",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayScrollSelectedEvent",
+    "Description": "Move back or forward through events list      Value = Count -10-10",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplaySelectAllEvents",
+    "Description": "Select all events in active channel.",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplaySelectChannelA",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplaySelectChannelAB",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplaySelectChannelB",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplaySelectedEventCameraOff",
+    "Description": "Turns off the specified camera angle (1-8)      Value = Camera",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplaySelectedEventCameraOn",
+    "Description": "Turns on the specified camera angle (1-8)      Value = Camera",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplaySelectedEventSingleCameraOn",
+    "Description": "Turns on only the specified camera angle (1-8)      Value = Camera",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents1",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents10",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents11",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents12",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents13",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents14",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents15",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents16",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents17",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents18",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents19",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents2",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents20",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents3",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents4",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents5",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents6",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents7",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents8",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectEvents9",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectFirstEvent",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectLastEvent",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectNextEvent",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySelectPreviousEvent",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySetAudioSource",
+    "Description": "Name as per dropdown box. e.g 'Camera1'      Value = AudioSource",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplaySetChannelAToBTimecode",
+    "Description": "Set A Timecode to B Timecode",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplaySetChannelAToBTimecodeAndCamera",
+    "Description": "Set A Timecode and Camera to B",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplaySetChannelBToATimecode",
+    "Description": "Set B Timecode to A Timecode",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplaySetChannelBToATimecodeAndCamera",
+    "Description": "Set B Timecode and Camera to A",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplaySetDirectionBackward",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySetDirectionForward",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySetLastEventText",
+    "Description": "Value = Text",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplaySetLastEventTextCamera",
+    "Description": "Changes the text of the specified angle (1-4), example: 3,angle3text      Value = Camera,Text",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplaySetSelectedEventText",
+    "Description": "Value = Text",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplaySetSelectedEventTextCamera",
+    "Description": "Changes the text of the specified angle (1-4), example: 3,angle3text      Value = Camera,Text",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "ReplaySetSpeed",
+    "Description": "See SetRateSlowMotion      Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplaySetTimecode",
+    "Description": "Set position to Timecode in format yyyy-MM-ddTHH:mm:ss.fff      Value = Timecode",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayShowHide",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayStartRecording",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayStartStopRecording",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayStopEvents",
+    "Description": "",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayStopRecording",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplaySwapChannels",
+    "Description": "Swap A to B and vice versa, includes angles and playback status.",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleLastEventCamera1",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleLastEventCamera2",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleLastEventCamera3",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleLastEventCamera4",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleLastEventCamera5",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleLastEventCamera6",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleLastEventCamera7",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleLastEventCamera8",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleQuadMode",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleSelectedEventCamera1",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleSelectedEventCamera2",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleSelectedEventCamera3",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleSelectedEventCamera4",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleSelectedEventCamera5",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleSelectedEventCamera6",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleSelectedEventCamera7",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayToggleSelectedEventCamera8",
+    "Description": "",
+    "Parameters": null
+  },
+  {
+    "Name": "ReplayUpdateSelectedInPoint",
+    "Description": "Update In point of Selected Event to current Position.",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayUpdateSelectedOutPoint",
+    "Description": "Update Mark Out point of Selected Event to current Position.",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayUpdateSelectedSpeed",
+    "Description": "Update Selected Event to use Current Speed.",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayUpdateSelectedSpeedDefault",
+    "Description": "Update Selected Event to use Default Speed.",
+    "Parameters": [
+      "Channel"
+    ]
+  },
+  {
+    "Name": "ReplayUpdateSelectedSpeedFromValue",
+    "Description": "See SetRateSlowMotion      Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Channel"
+    ]
+  },
+  {
+    "Name": "NDICommand",
+    "Description": "Send specified command to NDI source      Value = Command",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "NDISelectSourceByIndex",
+    "Description": "Value = Index 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "NDISelectSourceByName",
+    "Description": "Value = Name",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "NDIStartRecording",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "NDIStopRecording",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "OMTSelectSourceByIndex",
+    "Description": "Value = Index 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "OMTSelectSourceByName",
+    "Description": "Value = Name",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZCreateVirtualInput",
+    "Description": "Creates a PTZ Virtual Input with the current Position",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZFocusAuto",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZFocusFar",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZFocusManual",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZFocusNear",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZFocusStop",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZHome",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZMoveDown",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZMoveDownLeft",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZMoveDownRight",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZMoveLeft",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZMoveRight",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZMoveStop",
+    "Description": "Stop all PTZ movement",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZMoveToVirtualInputPosition",
+    "Description": "Moves to the Position of the PTZ Virtual Input without selecting it into Preview",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZMoveToVirtualInputPositionByIndex",
+    "Description": "Moves to the Position of the PTZ Virtual Input associated with this Input. Index is first Input found starting from 0      Value = Index 0-100",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZMoveUp",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZMoveUpLeft",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZMoveUpRight",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZUpdateVirtualInput",
+    "Description": "Updates selected PTZ Virtual Input with current Position",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZZoomIn",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZZoomOut",
+    "Description": "Value = Speed 0-1",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "PTZZoomStop",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "LastPreset",
+    "Description": "Load the last preset.",
+    "Parameters": null
+  },
+  {
+    "Name": "OpenPreset",
+    "Description": "Load preset from the specified Filename.      Value = Filename",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "SavePreset",
+    "Description": "Save preset to the specified Filename.      Value = Filename",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "DataSourceAutoNextOff",
+    "Description": "Name of the Data Source, Table Name (optional) eg 'Excel/CSV,Sheet1'      Value = Name,Table",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "DataSourceAutoNextOn",
+    "Description": "Name of the Data Source, Table Name (optional) eg 'Excel/CSV,Sheet1'      Value = Name,Table",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "DataSourceAutoNextOnOff",
+    "Description": "Name of the Data Source, Table Name (optional) eg 'Excel/CSV,Sheet1'      Value = Name,Table",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "DataSourceNextRow",
+    "Description": "Name of the Data Source and Table Name (optional) eg 'Excel/CSV,Sheet1'      Value = Name,Table",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "DataSourcePause",
+    "Description": "Name of Data Source eg 'Excel/CSV'      Value = Name",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "DataSourcePlay",
+    "Description": "Name of Data Source eg 'Excel/CSV'      Value = Name",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "DataSourcePlayPause",
+    "Description": "Name of Data Source eg 'Excel/CSV'      Value = Name",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "DataSourcePreviousRow",
+    "Description": "Name of the Data Source and Table Name (optional) eg 'Excel/CSV,Sheet1'      Value = Name,Table",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "DataSourceSelectRow",
+    "Description": "Name of the Data Source, Table Name (optional) and Row Index starting from 0 eg 'Excel/CSV,Sheet1,5'      Value = Name,Table,Index",
+    "Parameters": [
+      "Value"
+    ]
+  },
+  {
+    "Name": "BrowserBack",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "BrowserForward",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "BrowserKeyboardDisabled",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "BrowserKeyboardEnabled",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "BrowserMouseDisabled",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "BrowserMouseEnabled",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  },
+  {
+    "Name": "BrowserNavigate",
+    "Description": "URL      Value = URL",
+    "Parameters": [
+      "Value",
+      "Input"
+    ]
+  },
+  {
+    "Name": "BrowserReload",
+    "Description": "",
+    "Parameters": [
+      "Input"
+    ]
+  }
+]

--- a/scraper/cmd/main.go
+++ b/scraper/cmd/main.go
@@ -16,7 +16,7 @@ var (
 )
 
 func main() {
-	flag.IntVar(&helpVer, "helpver", 28, "vMix Help Version")
+	flag.IntVar(&helpVer, "helpver", 29, "vMix Help Version")
 	flag.StringVar(&dumpPath, "dumppath", "../app/src/assets", "Path to dump the shortcuts.json file")
 	flag.Parse()
 
@@ -33,7 +33,9 @@ func main() {
 	}
 	defer dumpFile.Close()
 
-	if err := json.NewEncoder(dumpFile).Encode(sc); err != nil {
+	enc := json.NewEncoder(dumpFile)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(sc); err != nil {
 		panic(err)
 	}
 

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -13,33 +13,34 @@ type Shortcut struct {
 	Parameters  []string // comma-separated queries
 }
 
+func transitionShortcut(name string, params ...string) Shortcut {
+	return Shortcut{Name: name, Description: name, Parameters: params}
+}
+
 // OverrideShortcuts is a list of shortcuts that are not on the official documentation.
+// Transition names match the vMix UI and can be used as Functions; Duration is a
+// Developer API parameter for transitions and is not listed in the reference table.
 var OverrideShortcuts = []Shortcut{
-	{
-		Name:        "Cut",
-		Description: "Cut",
-		Parameters: []string{
-			"Input",
-			"Mix",
-		},
-	},
-	{
-		Name:        "Fade",
-		Description: "Fade",
-		Parameters: []string{
-			"Input",
-			"Mix",
-			"Duration",
-		},
-	},
-	{
-		Name:        "Merge",
-		Description: "Merge",
-		Parameters: []string{
-			"Input",
-			"Duration",
-		},
-	},
+	transitionShortcut("Cut", "Input", "Mix"),
+	transitionShortcut("Fade", "Input", "Mix", "Duration"),
+	transitionShortcut("Zoom", "Input", "Mix", "Duration"),
+	transitionShortcut("Wipe", "Input", "Mix", "Duration"),
+	transitionShortcut("Slide", "Input", "Mix", "Duration"),
+	transitionShortcut("Fly", "Input", "Mix", "Duration"),
+	transitionShortcut("CrossZoom", "Input", "Mix", "Duration"),
+	transitionShortcut("FlyRotate", "Input", "Mix", "Duration"),
+	transitionShortcut("Cube", "Input", "Mix", "Duration"),
+	transitionShortcut("CubeZoom", "Input", "Mix", "Duration"),
+	transitionShortcut("VerticalWipe", "Input", "Mix", "Duration"),
+	transitionShortcut("VerticalSlide", "Input", "Mix", "Duration"),
+	transitionShortcut("Merge", "Input", "Duration"),
+	transitionShortcut("WipeReverse", "Input", "Mix", "Duration"),
+	transitionShortcut("SlideReverse", "Input", "Mix", "Duration"),
+	transitionShortcut("VerticalWipeReverse", "Input", "Mix", "Duration"),
+	transitionShortcut("VerticalSlideReverse", "Input", "Mix", "Duration"),
+	transitionShortcut("BarnDoor", "Input", "Mix", "Duration"),
+	transitionShortcut("RollerDoor", "Input", "Mix", "Duration"),
+	transitionShortcut("AlphaFade", "Input", "Mix", "Duration"),
 }
 
 func GetShortcuts(helpVer int) ([]Shortcut, error) {


### PR DESCRIPTION
## Summary
- OverlayInput1-8 の Mix を含むよう、scraper の既定 helpver を 29 に変更し shortcuts.json を再生成しました。
- Fade / Merge および Wipe / Slide / Zoom などの Transition 系に Duration を追加しました。
- shortcuts.json をインデント付きの複数行出力にし、git diff を取りやすくしました。

## Test plan
- [ ] Shortcut Generator で OverlayInput1 / OverlayInput5 を選び、「クエリを適用」で Mix が入ること
- [ ] Fade / Merge / Wipe / Slide で Duration が追加されること
- [ ] 生成された JSON が複数行で Function 単位に diff できること

Closes #284