### PR TITLE
fix: keep Shortcut Generator TRY/Copy clear of toast overlay

### DIFF
--- a/app/src/pages/ShortcutGenerator.tsx
+++ b/app/src/pages/ShortcutGenerator.tsx
@@ -88,6 +88,8 @@ const VirtualizedInputList = FixedSizeList as unknown as ComponentType<
 
 const FUNCTION_NAME_COMMIT_MS = 400;
 const MAX_SHORTCUT_SUGGESTIONS = 50;
+/** Extra bottom space so the toast snackbar does not cover TRY/Copy on the last visible row. */
+const TOAST_FOOTER_SPACING = 8;
 
 interface FunctionNameFieldHandle {
   commitAndGet: () => string;
@@ -842,6 +844,7 @@ const ShortcutGenerator = () => {
   return (
     <Box sx={{ 
       p: spacing.cardPadding * 3,
+      pb: spacing.cardPadding * 3 + TOAST_FOOTER_SPACING,
       height: '100%',
       display: 'flex',
       flexDirection: 'column',

--- a/app/src/pages/ShortcutGenerator.tsx
+++ b/app/src/pages/ShortcutGenerator.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, memo, useRef, useEffect, useTransition, forwardRef, useImperativeHandle, type ComponentType } from 'react';
+import { useState, useMemo, useCallback, memo, useRef, useEffect, useTransition, forwardRef, useImperativeHandle, type ComponentType, type HTMLAttributes } from 'react';
 import type { TFunction } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { openUrl } from '@tauri-apps/plugin-opener';
@@ -88,8 +88,29 @@ const VirtualizedInputList = FixedSizeList as unknown as ComponentType<
 
 const FUNCTION_NAME_COMMIT_MS = 400;
 const MAX_SHORTCUT_SUGGESTIONS = 50;
-/** Extra bottom space so the toast snackbar does not cover TRY/Copy on the last visible row. */
-const TOAST_FOOTER_SPACING = 8;
+/** Extra scrollable space after the last row so the toast does not cover TRY/Copy. */
+const LIST_BOTTOM_PADDING_PX = 48;
+
+const VirtualizedListInnerElement = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  function VirtualizedListInnerElement({ style, ...rest }, ref) {
+    const heightValue = style?.height;
+    const baseHeight =
+      typeof heightValue === 'number'
+        ? heightValue
+        : parseFloat(String(heightValue ?? 0)) || 0;
+
+    return (
+      <div
+        ref={ref}
+        style={{
+          ...style,
+          height: baseHeight + LIST_BOTTOM_PADDING_PX,
+        }}
+        {...rest}
+      />
+    );
+  }
+);
 
 interface FunctionNameFieldHandle {
   commitAndGet: () => string;
@@ -844,7 +865,6 @@ const ShortcutGenerator = () => {
   return (
     <Box sx={{ 
       p: spacing.cardPadding * 3,
-      pb: spacing.cardPadding * 3 + TOAST_FOOTER_SPACING,
       height: '100%',
       display: 'flex',
       flexDirection: 'column',
@@ -1303,6 +1323,7 @@ const ShortcutGenerator = () => {
                 height={listHeight}
                 itemCount={filteredInputs.length}
                 itemSize={spacing.itemHeight + 8}
+                innerElementType={VirtualizedListInnerElement}
                 itemData={useMemo(() => ({
                   filteredInputs,
                   vmixInputsByNumber,


### PR DESCRIPTION
## Summary
- Shortcut Generator の最下部で通知トーストが TRY/Copy などの操作ボタンに被り、クリックできない問題を修正しました。
- ページフッターに余白を追加し、トースト表示中も最後の行のアクションボタンを操作できるようにしました。

## Test plan
- [ ] Shortcut Generator を開き、リスト最下部の行で Copy / TRY を実行する
- [ ] トースト表示中に同じ行の Copy / TRY / Script / Tally / Key がクリックできることを確認する
- [ ] トーストが消えたあともレイアウトが崩れていないことを確認する

Fixes #285